### PR TITLE
name in bower.json should match registered name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "navigation",
+  "name": "d2l-navigation",
   "description": "Parent repo for all navigation based web components",
   "main": "index.html",
   "license": "Apache-2.0",


### PR DESCRIPTION
This is so you can go `bower link d2l-navigation` and have it actually work. :)