### PR TITLE
Add more assertion checks on the structure of the header and footer elements

### DIFF
--- a/test/navigation-main-footer.html
+++ b/test/navigation-main-footer.html
@@ -17,8 +17,20 @@
 		<script>
 			suite('d2l-navigation-main-footer', function() {
 				test('instantiating the element works', function() {
-					var element = fixture('basic');
-					assert.equal(element.is, 'd2l-navigation-main-footer');
+					var footer = fixture('basic');
+					assert.equal(footer.is, 'd2l-navigation-main-footer');
+
+					var centerer = Polymer.dom(footer.root).querySelector('.d2l-navigation-centerer');
+					expect(centerer).to.not.be.null;
+					assert.equal(centerer.tagName, 'DIV');
+
+					var ancestor = Polymer.dom(footer.root).querySelector('.d2l-visible-on-ancestor-target');
+					expect(ancestor).to.not.be.null;
+					assert.equal(ancestor.tagName, 'DIV');
+
+					var gutters = Polymer.dom(footer.root).querySelector('.d2l-navigation-gutters');
+					expect(gutters).to.not.be.null;
+					assert.equal(gutters.tagName, 'DIV');
 				});
 			});
 		</script>

--- a/test/navigation-main-header.html
+++ b/test/navigation-main-header.html
@@ -17,8 +17,24 @@
 		<script>
 			suite('d2l-navigation-main-header', function() {
 				test('instantiating the element works', function() {
-					var element = fixture('basic');
-					assert.equal(element.is, 'd2l-navigation-main-header');
+					var header = fixture('basic');
+					assert.equal(header.is, 'd2l-navigation-main-header');
+
+					var centerer = Polymer.dom(header.root).querySelector('.d2l-navigation-centerer');
+					expect(centerer).to.not.be.null;
+					assert.equal(centerer.tagName, 'DIV');
+
+					var gutters = Polymer.dom(header.root).querySelector('.d2l-navigation-gutters');
+					expect(gutters).to.not.be.null;
+					assert.equal(gutters.tagName, 'DIV');
+
+					var container = Polymer.dom(header.root).querySelector('.d2l-navigation-header-container');
+					expect(container).to.not.be.null;
+					assert.equal(container.tagName, 'DIV');
+
+					var gutter = Polymer.dom(header.root).querySelector('.d2l-navigation-gutter');
+					expect(gutter).to.not.be.null;
+					assert.equal(gutter.tagName, 'DIV');
 				});
 			});
 		</script>


### PR DESCRIPTION
Have been trying to get slot asserts to work, unsuccessfully so far.

At least these asserts are better than the minimal check we had before.