### PR TITLE
Add aria-describedby to the button

### DIFF
--- a/d2l-navigation-button-notification-icon.html
+++ b/d2l-navigation-button-notification-icon.html
@@ -105,7 +105,6 @@ This button contains a user-supplied icon, as well as a notification marker.
 				D2L.PolymerBehaviors.FocusableBehavior
 			],
 			_getNotificationTextId: function(notification) {
-				console.log('here');
 				return notification ? 'notification-text' : '';
 			}
 		});

--- a/d2l-navigation-button-notification-icon.html
+++ b/d2l-navigation-button-notification-icon.html
@@ -53,7 +53,7 @@ This button contains a user-supplied icon, as well as a notification marker.
 			aria-expanded$="[[ariaExpanded]]"
 			aria-haspopup$="[[ariaHaspopup]]"
 			aria-label$="[[ariaLabel]]"
-			aria-describedby-text="[[notificationText]]"
+			aria-describedby-text="[[_getNotificationText(notification, notificationText)]]"
 			disabled$=[[disabled]]
 			autofocus$=[[autofocus]]
 			form$=[[form]]
@@ -94,7 +94,10 @@ This button contains a user-supplied icon, as well as a notification marker.
 			behaviors: [
 				D2L.PolymerBehaviors.Button.Behavior,
 				D2L.PolymerBehaviors.FocusableBehavior
-			]
+			],
+			_getNotificationText: function(notification, notificationText) {
+				return notification ? notificationText : '';
+			}
 		});
 	</script>
 </dom-module>

--- a/d2l-navigation-button-notification-icon.html
+++ b/d2l-navigation-button-notification-icon.html
@@ -5,7 +5,6 @@
 <link rel="import" href="../d2l-icons/tier2-icons.html">
 <link rel="import" href="../d2l-button/d2l-button-behavior.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-behavior.html">
-<link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
 
 <!--
 `d2l-navigation-button-notification-icon`
@@ -49,19 +48,12 @@ This button contains a user-supplied icon, as well as a notification marker.
 				width: 10px;
 				border-radius: 50%;
 			}
-			.d2l-navigation-button-notification-indicator-text {
-				@apply --d2l-offscreen;
-			}
-			:host-context([dir="rtl"]) .d2l-navigation-button-notification-indicator-text,
-			:host(:dir(rtl)) .d2l-navigation-button-notification-indicator-text {
-				@apply --d2l-offscreen-rtl;
-			}
 		</style>
 		<d2l-navigation-button
-			aria-describedby="[[_getNotificationTextId(notification)]]"
 			aria-expanded$="[[ariaExpanded]]"
 			aria-haspopup$="[[ariaHaspopup]]"
 			aria-label$="[[ariaLabel]]"
+			aria-describedby-text="[[notificationText]]"
 			disabled$=[[disabled]]
 			autofocus$=[[autofocus]]
 			form$=[[form]]
@@ -77,7 +69,6 @@ This button contains a user-supplied icon, as well as a notification marker.
 				<d2l-icon icon="[[icon]]" class="d2l-navigation-button-icon"></d2l-icon>
 				<span class="d2l-navigation-button-notification-indicator">
 					<div class="d2l-navigation-button-notification-indicator-icon"></div>
-					<span id="notification-text" class="d2l-navigation-button-notification-indicator-text">[[notificationText]]</span>
 				</span>
 			</span>
 		</d2l-navigation-button>
@@ -103,10 +94,7 @@ This button contains a user-supplied icon, as well as a notification marker.
 			behaviors: [
 				D2L.PolymerBehaviors.Button.Behavior,
 				D2L.PolymerBehaviors.FocusableBehavior
-			],
-			_getNotificationTextId: function(notification) {
-				return notification ? 'notification-text' : '';
-			}
+			]
 		});
 	</script>
 </dom-module>

--- a/d2l-navigation-button-notification-icon.html
+++ b/d2l-navigation-button-notification-icon.html
@@ -48,7 +48,7 @@ This button contains a user-supplied icon, as well as a notification marker.
 				height: 10px;
 				width: 10px;
 				border-radius: 50%;
-			}			
+			}
 			.d2l-navigation-button-notification-indicator-text {
 				@apply --d2l-offscreen;
 			}
@@ -58,6 +58,7 @@ This button contains a user-supplied icon, as well as a notification marker.
 			}
 		</style>
 		<d2l-navigation-button
+			aria-describedby="[[_getNotificationTextId(notification)]]"
 			aria-expanded$="[[ariaExpanded]]"
 			aria-haspopup$="[[ariaHaspopup]]"
 			aria-label$="[[ariaLabel]]"
@@ -76,7 +77,7 @@ This button contains a user-supplied icon, as well as a notification marker.
 				<d2l-icon icon="[[icon]]" class="d2l-navigation-button-icon"></d2l-icon>
 				<span class="d2l-navigation-button-notification-indicator">
 					<div class="d2l-navigation-button-notification-indicator-icon"></div>
-					<span class="d2l-navigation-button-notification-indicator-text">[[notificationText]]</span>
+					<span id="notification-text" class="d2l-navigation-button-notification-indicator-text">[[notificationText]]</span>
 				</span>
 			</span>
 		</d2l-navigation-button>
@@ -102,7 +103,11 @@ This button contains a user-supplied icon, as well as a notification marker.
 			behaviors: [
 				D2L.PolymerBehaviors.Button.Behavior,
 				D2L.PolymerBehaviors.FocusableBehavior
-			]
+			],
+			_getNotificationTextId: function(notification) {
+				console.log('here');
+				return notification ? 'notification-text' : '';
+			}
 		});
 	</script>
 </dom-module>

--- a/d2l-navigation-button.html
+++ b/d2l-navigation-button.html
@@ -24,14 +24,14 @@ Polymer-based web component for buttons used in the navigational header.
 			{
 				@apply --d2l-navigation-highlight-base-hover-focus;
 			}
-			/* 	
-				::slotted styles for Polymer 1.0; styling all slotted children needs 
+			/*
+				::slotted styles for Polymer 1.0; styling all slotted children needs
 				to be applied explicitely.
-				This cannot be combined with the style block above, as this is not 
-				valid in 2.0 and as such the entire block gets ignored. 
+				This cannot be combined with the style block above, as this is not
+				valid in 2.0 and as such the entire block gets ignored.
 			*/
 			:host(:not([disabled])) button:hover ::slotted(*) *,
-			:host(:not([disabled])) button:focus ::slotted(*) * 
+			:host(:not([disabled])) button:focus ::slotted(*) *
 			{
 				@apply --d2l-navigation-highlight-base-hover-focus;
 			}
@@ -48,6 +48,7 @@ Polymer-based web component for buttons used in the navigational header.
 			}
 		</style>
 		<button
+			aria-describedby$="[[ariaDescribedby]]"
 			aria-expanded$="[[ariaExpanded]]"
 			aria-haspopup$="[[ariaHaspopup]]"
 			aria-label$="[[text]]"
@@ -72,6 +73,10 @@ Polymer-based web component for buttons used in the navigational header.
 			is: 'd2l-navigation-button',
 			properties: {
 				text: {
+					type: String,
+					reflectToAttribute: true
+				},
+				ariaDescribedby: {
 					type: String,
 					reflectToAttribute: true
 				}

--- a/d2l-navigation-button.html
+++ b/d2l-navigation-button.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-button/d2l-button-behavior.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-behavior.html">
+<link rel="import" href="../d2l-polymer-behaviors/d2l-id.html">
 <link rel="import" href="d2l-navigation-highlight-styles.html">
 <link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
 
@@ -56,7 +57,7 @@ Polymer-based web component for buttons used in the navigational header.
 			}
 		</style>
 		<button
-			aria-describedby="aria-description"
+			aria-describedby$="[[_ariaDescriptionId]]"
 			aria-expanded$="[[ariaExpanded]]"
 			aria-haspopup$="[[ariaHaspopup]]"
 			aria-label$="[[text]]"
@@ -75,7 +76,7 @@ Polymer-based web component for buttons used in the navigational header.
 			<span class="d2l-navigation-button-top-border"></span>
 			<slot></slot>
 		</button>
-		<span id="aria-description" class="d2l-offscreen-description">[[ariaDescribedbyText]]</span>
+		<span id="[[_ariaDescriptionId]]" class="d2l-offscreen-description">[[ariaDescribedbyText]]</span>
 	</template>
 	<script>
 		Polymer({
@@ -87,12 +88,18 @@ Polymer-based web component for buttons used in the navigational header.
 				},
 				ariaDescribedbyText: {
 					type: String
+				},
+				_ariaDescriptionId: {
+					type: String
 				}
 			},
 			behaviors: [
 				D2L.PolymerBehaviors.Button.Behavior,
 				D2L.PolymerBehaviors.FocusableBehavior
-			]
+			],
+			ready: function() {
+				this._ariaDescriptionId = D2L.Id.getUniqueId();
+			}
 		});
 	</script>
 </dom-module>

--- a/d2l-navigation-button.html
+++ b/d2l-navigation-button.html
@@ -2,6 +2,7 @@
 <link rel="import" href="../d2l-button/d2l-button-behavior.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-focusable-behavior.html">
 <link rel="import" href="d2l-navigation-highlight-styles.html">
+<link rel="import" href="../d2l-offscreen/d2l-offscreen-shared-styles.html">
 
 <!--
 `d2l-navigation-button`
@@ -46,9 +47,16 @@ Polymer-based web component for buttons used in the navigational header.
 			.d2l-navigation-button-top-border {
 				@apply --d2l-navigation-highlight-border;
 			}
+			.d2l-offscreen-description {
+				@apply --d2l-offscreen;
+			}
+			:host-context([dir="rtl"]) .d2l-offscreen-description,
+			:host(:dir(rtl)) .d2l-offscreen-description {
+				@apply --d2l-offscreen-rtl;
+			}
 		</style>
 		<button
-			aria-describedby$="[[ariaDescribedby]]"
+			aria-describedby="aria-description"
 			aria-expanded$="[[ariaExpanded]]"
 			aria-haspopup$="[[ariaHaspopup]]"
 			aria-label$="[[text]]"
@@ -67,6 +75,7 @@ Polymer-based web component for buttons used in the navigational header.
 			<span class="d2l-navigation-button-top-border"></span>
 			<slot></slot>
 		</button>
+		<span id="aria-description" class="d2l-offscreen-description">[[ariaDescribedbyText]]</span>
 	</template>
 	<script>
 		Polymer({
@@ -76,9 +85,8 @@ Polymer-based web component for buttons used in the navigational header.
 					type: String,
 					reflectToAttribute: true
 				},
-				ariaDescribedby: {
-					type: String,
-					reflectToAttribute: true
+				ariaDescribedbyText: {
+					type: String
 				}
 			},
 			behaviors: [

--- a/demo/d2l-navigation-button.html
+++ b/demo/d2l-navigation-button.html
@@ -107,8 +107,9 @@
 					<d2l-navigation-band></d2l-navigation-band>
 					<div class="button-holder">
 						<d2l-navigation-button><span><d2l-icon icon="d2l-tier3:classes"></d2l-icon><span>TEST</span></span></d2l-navigation-button>
-						<d2l-navigation-button-notification-icon icon="d2l-tier3:classes" text="Notification off" notification-text="notification text"></d2l-navigation-button-notification-icon>
-						<d2l-navigation-button-notification-icon notification icon="d2l-tier3:notification-bell" text="Notification on" id="notified" notification-text="notification text"></d2l-navigation-button-notification-icon>
+						<d2l-navigation-button-notification-icon icon="d2l-tier3:notification-bell" text="Notification off"></d2l-navigation-button-notification-icon>
+						<d2l-navigation-button-notification-icon icon="d2l-tier3:classes" text="Notification off" notification-text="No new notifications"></d2l-navigation-button-notification-icon>
+						<d2l-navigation-button-notification-icon notification icon="d2l-tier3:notification-bell" text="Notification on" id="notified" notification-text="You have new notifications"></d2l-navigation-button-notification-icon>
 						<d2l-navigation-button-close></d2l-navigation-button-close>
 						<d2l-navigation-button-notification-icon icon="d2l-tier3:classes" text="text" disabled></d2l-navigation-button-notification-icon>
 						<d2l-navigation-button-close disabled></d2l-navigation-button-close>

--- a/demo/d2l-navigation-button.html
+++ b/demo/d2l-navigation-button.html
@@ -107,8 +107,7 @@
 					<d2l-navigation-band></d2l-navigation-band>
 					<div class="button-holder">
 						<d2l-navigation-button><span><d2l-icon icon="d2l-tier3:classes"></d2l-icon><span>TEST</span></span></d2l-navigation-button>
-						<d2l-navigation-button-notification-icon icon="d2l-tier3:notification-bell" text="Notification off"></d2l-navigation-button-notification-icon>
-						<d2l-navigation-button-notification-icon icon="d2l-tier3:classes" text="Notification off" notification-text="No new notifications"></d2l-navigation-button-notification-icon>
+						<d2l-navigation-button-notification-icon icon="d2l-tier3:classes" text="Notification off" notification-text="This text will not be added"></d2l-navigation-button-notification-icon>
 						<d2l-navigation-button-notification-icon notification icon="d2l-tier3:notification-bell" text="Notification on" id="notified" notification-text="You have new notifications"></d2l-navigation-button-notification-icon>
 						<d2l-navigation-button-close></d2l-navigation-button-close>
 						<d2l-navigation-button-notification-icon icon="d2l-tier3:classes" text="text" disabled></d2l-navigation-button-notification-icon>

--- a/test/d2l-navigation-button.html
+++ b/test/d2l-navigation-button.html
@@ -113,9 +113,14 @@
 					var title = button.$$('d2l-navigation-button').text;
 					assert.equal(button.text, title);
 				});
-				test('should pass notificationText property to notification span', function() {
-					var nText = button.$$('.d2l-navigation-button-notification-indicator-text').innerHTML;
+				test('should pass notificationText property to offscreen span', function() {
+					var nText = button.$$('d2l-navigation-button').$$('.d2l-offscreen-description').innerHTML;
 					assert.equal(button.notificationText, nText);
+				});
+				test('should NOT pass notificationText property if the notification attribute is not present', function() {
+					button.removeAttribute('notification');
+					var nText = button.$$('d2l-navigation-button').$$('.d2l-offscreen-description').innerHTML;
+					assert.equal('', nText);
 				});
 				test('notification icon should not change colour on focus', function() {
 					var btn = button.$$('d2l-navigation-button').$$('button');


### PR DESCRIPTION
This fixes the NVDA screenreader problem we were seeing where the notification text was ignored.  It unfortunately only works in Shady DOM, because in Shadow DOM the button cannot see the `d2l-navigation-button`'s slot contents.