### PR TITLE
Make d2l-navigation-immersive sticky

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Then add the `d2l-navigation`, and provide sub elements `d2l-navigation-main-hea
 </d2l-navigation>
 ```
 
+***Relevant CSS class name:***
+* `--d2l-navigation-shadow-gradient-display`: The default value is `block`, but this property can be used to hide the gradient by setting it to `none`.  Instead of doing this, **PLEASE STRONGLY CONSIDER** fixing the issues with the z-index elements on your page.  This was added to address an issue we've seen with a few pages that use tables with sticky headers.
+
 ### d2l-navigation-immersive
 
 Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyfill (for browsers who don't natively support web components), then import the following:

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="d2l-navigation.html">
 <link rel="import" href="d2l-navigation-link-back.html">
+<link rel="import" href="d2l-navigation-shared-styles.html">
 
 <!--
 `d2l-navigation-immersive`
@@ -16,8 +17,17 @@ Polymer-based web component for the immersive navigation component
 
 <dom-module id="d2l-navigation-immersive">
 	<template strip-whitespace>
-		<style>
+		<style include="d2l-navigation-shared-styles">
+			.d2l-navigiation-immersive-fixed {
+				background-color: white;
+				left: 0px;
+				position: fixed;
+				right: 0px;
+				top: 0px;
+				z-index: 1;
+			}
 			d2l-navigation {
+				--d2l-navigation-shadow-gradient-display: none;
 				border-bottom: 1px solid var(--d2l-color-mica);
 			}
 			.d2l-navigation-immersive-margin {
@@ -72,6 +82,13 @@ Polymer-based web component for the immersive navigation component
 				--d2l-navigation-link-back-left-padding: 12px;
 			}
 
+			.d2l-navigation-shadow-gradient {
+				left: 0px;
+				position: fixed;
+				right: 0px;
+				top: 3.1rem;
+			}
+
 			@media (max-width: 929px) {
 				.d2l-navigation-immersive-margin {
 					margin: 0px 24px;
@@ -88,6 +105,9 @@ Polymer-based web component for the immersive navigation component
 				.d2l-navigation-immersive-container {
 					height: 2.8rem;
 				}
+				.d2l-navigation-shadow-gradient {
+					top: 2.8rem;
+				}
 				.d2l-navigation-immersive-middle {
 					margin: 0px 18px;
 					padding: 0px 18px;
@@ -96,24 +116,28 @@ Polymer-based web component for the immersive navigation component
 					--d2l-navigation-link-back-left-padding: 6px;
 				}
 			}
+
 		</style>
-		<d2l-navigation>
-			<div class="d2l-navigation-immersive-margin">
-				<div class="d2l-navigation-immersive-container">
-					<div class="d2l-navigation-immersive-left">
-						<slot name="left">
-							<d2l-navigation-link-back text="[[backLinkText]]" href="[[backLinkHref]]"></d2l-navigation-link-back>
-						</slot>
-					</div>
-					<div class="d2l-navigation-immersive-middle">
-			    		<slot name="middle"></slot>
-					</div>
-					<div class="d2l-navigation-immersive-right">
-		    			<slot name="right"></slot>
+		<div class="d2l-navigiation-immersive-fixed">
+			<d2l-navigation>
+				<div class="d2l-navigation-immersive-margin">
+					<div class="d2l-navigation-immersive-container">
+						<div class="d2l-navigation-immersive-left">
+							<slot name="left">
+								<d2l-navigation-link-back text="[[backLinkText]]" href="[[backLinkHref]]"></d2l-navigation-link-back>
+							</slot>
+						</div>
+						<div class="d2l-navigation-immersive-middle">
+				    		<slot name="middle"></slot>
+						</div>
+						<div class="d2l-navigation-immersive-right">
+			    			<slot name="right"></slot>
+						</div>
 					</div>
 				</div>
-			</div>
-		</d2l-navigation>
+			</d2l-navigation>
+		</div>
+		<div class="d2l-navigation-shadow-gradient"></div>
 	</template>
 	<script>
 		Polymer({

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -20,10 +20,10 @@ Polymer-based web component for the immersive navigation component
 		<style include="d2l-navigation-shared-styles">
 			.d2l-navigiation-immersive-fixed {
 				background-color: white;
-				left: 0px;
+				left: 0;
 				position: fixed;
-				right: 0px;
-				top: 0px;
+				right: 0;
+				top: 0;
 				z-index: 1;
 			}
 			d2l-navigation {
@@ -31,14 +31,14 @@ Polymer-based web component for the immersive navigation component
 				border-bottom: 1px solid var(--d2l-color-mica);
 			}
 			.d2l-navigation-immersive-margin {
-				margin: 0px 30px;
+				margin: 0 30px;
 			}
 
 			.d2l-navigation-immersive-container {
 				display: flex;
 				height: 3.1rem;
 				justify-content: space-between;
-				margin: 0px -7px;
+				margin: 0 -7px;
 				max-width: 1230px;
 				overflow: hidden;
 			}
@@ -69,8 +69,8 @@ Polymer-based web component for the immersive navigation component
 				border-left: 1px solid var(--d2l-color-gypsum);
 				border-right: 1px solid var(--d2l-color-gypsum);
 				flex: 0 1 auto;
-				margin: 0px 24px;
-				padding: 0px 24px;
+				margin: 0 24px;
+				padding: 0 24px;
 				width: 100%
 			}
 
@@ -83,21 +83,21 @@ Polymer-based web component for the immersive navigation component
 			}
 
 			.d2l-navigation-shadow-gradient {
-				left: 0px;
+				left: 0;
 				position: fixed;
-				right: 0px;
+				right: 0;
 				top: 3.1rem;
 			}
 
 			@media (max-width: 929px) {
 				.d2l-navigation-immersive-margin {
-					margin: 0px 24px;
+					margin: 0 24px;
 				}
 			}
 
 			@media (max-width: 767px) {
 				.d2l-navigation-immersive-margin {
-					margin: 0px 18px;
+					margin: 0 18px;
 				}
 			}
 
@@ -109,8 +109,8 @@ Polymer-based web component for the immersive navigation component
 					top: 2.8rem;
 				}
 				.d2l-navigation-immersive-middle {
-					margin: 0px 18px;
-					padding: 0px 18px;
+					margin: 0 18px;
+					padding: 0 18px;
 				}
 				d2l-navigation-link-back {
 					--d2l-navigation-link-back-left-padding: 6px;

--- a/d2l-navigation-shared-styles.html
+++ b/d2l-navigation-shared-styles.html
@@ -31,6 +31,17 @@
 					padding-right: 30px;
 				}
 			}
+
+			.d2l-navigation-shadow-gradient {
+				background: linear-gradient(to bottom,  rgba(249,250,251,1) 0%,rgba(249,250,251,0) 100%);
+				bottom: -150px;
+				display: var(--d2l-navigation-shadow-gradient-display, block);
+				height: 150px;
+				width: 100%;
+				pointer-events: none;
+				position: absolute;
+				z-index: -100;
+			}
 		</style>
 	</template>
 </dom-module>

--- a/d2l-navigation.html
+++ b/d2l-navigation.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="d2l-navigation-band.html">
+<link rel="import" href="d2l-navigation-shared-styles.html">
 
 <!--
 `d2l-navigation`
@@ -10,7 +11,7 @@ Polymer-based web component for the all encompasing navigation wrapper component
 
 <dom-module id="d2l-navigation">
 	<template strip-whitespace>
-		<style>
+		<style include="d2l-navigation-shared-styles">
 			:host {
 				display: block;
 				position: relative;
@@ -23,16 +24,6 @@ Polymer-based web component for the all encompasing navigation wrapper component
 				position: absolute;
 				width: 100%;
 			}
-			.d2l-navigation-shadow-gradient {
-				background: linear-gradient(to bottom,  rgba(249,250,251,1) 0%,rgba(249,250,251,0) 100%);
-				bottom: -150px;
-				height: 150px;
-				width: 100%;
-				pointer-events: none;
-				position: absolute;
-				z-index: -100;
-			}
-
 		</style>
 		<d2l-navigation-band></d2l-navigation-band>
 		<slot></slot>

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-navigation-immersive demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography-shared-styles.html">
+		<link rel="import" href="../../d2l-navigation-button.html">
+		<link rel="import" href="../../d2l-navigation-button-close.html">
+		<link rel="import" href="../../d2l-navigation-immersive.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles">
+				body {
+					background-color: pink;
+				}
+				demo-snippet {
+					--demo-snippet-demo: {
+						background-color: transparent;
+					}
+				}
+			</style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+			body {
+				overflow-x: hidden;
+			}
+			.page-contents {
+				margin-top: 3rem;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered" style="max-width: 900px;">
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+						<div class="d2l-typography d2l-body-standard" slot="middle">
+							<p>Economics 101</p>
+						</div>
+						<div slot="right">
+							<d2l-navigation-button text="A button">One Button</d2l-navigation-button>
+							<d2l-navigation-button-close></d2l-navigation-button-close>
+							<d2l-navigation-button text="Another button">Two Button</d2l-navigation-button>
+						</div>
+					</d2l-navigation-immersive>
+					<div class="page-contents">
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+					</div>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/navigation-immersive-demos/navigation-immersive-no-middle-slot.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-no-middle-slot.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-navigation-immersive demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../d2l-navigation-button.html">
+		<link rel="import" href="../../d2l-navigation-immersive.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles">
+				demo-snippet {
+					--demo-snippet-demo: {
+						background-color: transparent;
+					}
+				}
+			</style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+			body {
+				overflow-x: hidden;
+			}
+			.page-contents {
+				margin-top: 3rem;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered" style="max-width: 900px;">
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+						<div slot="right">
+							<d2l-navigation-button text="A third button">Three Button</d2l-navigation-button>
+						</div>
+					</d2l-navigation-immersive>
+					<div class="page-contents">
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+					</div>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/navigation-immersive-demos/navigation-immersive-no-slots.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-no-slots.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-navigation-immersive demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../d2l-navigation-immersive.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles">
+				demo-snippet {
+					--demo-snippet-demo: {
+						background-color: transparent;
+					}
+				}
+			</style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+			body {
+				overflow-x: hidden;
+			}
+			.page-contents {
+				margin-top: 3rem;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered" style="max-width: 900px;">
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+					</d2l-navigation-immersive>
+					<div class="page-contents">
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+					</div>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/navigation-immersive.html
+++ b/demo/navigation-immersive.html
@@ -22,42 +22,22 @@
 			html {
 				font-size: 20px;
 			}
+			iframe {
+				width: 100%;
+				height: 400px;
+			}
 		</style>
 	</head>
 	<body unresolved class="d2l-typography">
-		<div class="vertical-section-container centered" style="max-width: 900px;">
+		<div>
 			<h3>d2l-navigation-immersive</h3>
-			<demo-snippet>
-				<template strip-whitespace>
-					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
-						<div class="d2l-typography d2l-body-standard" slot="middle">
-							<p>Economics 101</p>
-						</div>
-						<div slot="right">
-							<d2l-navigation-button text="A button">One Button</d2l-navigation-button>
-							<d2l-navigation-button-close></d2l-navigation-button-close>
-							<d2l-navigation-button text="Another button">Two Button</d2l-navigation-button>
-						</div>
-					</d2l-navigation-immersive>
-				</template>
-			</demo-snippet>
+			<iframe src="./navigation-immersive-demos/navigation-immersive-all-slots.html"></iframe>
+
 			<h3>d2l-navigation-immersive (no middle slot)</h3>
-			<demo-snippet>
-				<template strip-whitespace>
-					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
-						<div slot="right">
-							<d2l-navigation-button text="A third button">Three Button</d2l-navigation-button>
-						</div>
-					</d2l-navigation-immersive>
-				</template>
-			</demo-snippet>
+			<iframe src="./navigation-immersive-demos/navigation-immersive-no-middle-slot.html"></iframe>
+
 			<h3>d2l-navigation-immersive (no middle slot, no right slot)</h3>
-			<demo-snippet>
-				<template strip-whitespace>
-					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
-					</d2l-navigation-immersive>
-				</template>
-			</demo-snippet>
+			<iframe src="./navigation-immersive-demos/navigation-immersive-no-slots.html"></iframe>
 		</div>
 	</body>
 </html>

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -10,12 +10,12 @@
       "browsers": [
         {
           "browserName": "chrome",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {
           "browserName": "firefox",
-          "platform": "OS X 10.12",
+          "platform": "OS X 10.13",
           "version": ""
         },
         {


### PR DESCRIPTION
This is a result of an issue we were seeing when trying to use the immersive nav in the Assignment Evaluations page, which has a fixed header.  Even with a `z-index` of `-100`, the gradient was overlappign the content below because the whole header is fixed. This is going to be an issue with everyone that wants the immersive nav to be sticky.  Since this is actually in the spec (http://design.d2l/components/immersive-navbar/) that the nav always be sticky, I think we should handle it here.  This PR:
- Adds `position: fixed` (not `sticky`, since that is not supported in IE11) to the immersive nav, sticking it to the top of the page
- Adjusts the demo page to be able to show and test this properly
- Exposes a new css variable `--d2l-navigation-shadow-gradient-display` that allows for the gradient to be hidden in `d2l-navigation` (needed for the grades page in Shadow DOM, and for this solution)