### PR TITLE
Add div for spacing of the immersive nav

### DIFF
--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -87,11 +87,8 @@ Polymer-based web component for the immersive navigation component
 			}
 
 			.d2l-navigation-immersive-spacing {
-				display: block;
 				height: calc(var(--d2l-navigation-immersive-height-main) + 5px);
-				margin: 0;
 				position: unset;
-				width: 100%;
 			}
 
 			.d2l-navigation-shadow-gradient {

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -18,6 +18,10 @@ Polymer-based web component for the immersive navigation component
 <dom-module id="d2l-navigation-immersive">
 	<template strip-whitespace>
 		<style include="d2l-navigation-shared-styles">
+			:host {
+				--d2l-navigation-immersive-height-main: 3.1rem;
+				--d2l-navigation-immersive-height-responsive: 2.8rem;
+			}
 			.d2l-navigiation-immersive-fixed {
 				background-color: white;
 				left: 0;
@@ -36,7 +40,7 @@ Polymer-based web component for the immersive navigation component
 
 			.d2l-navigation-immersive-container {
 				display: flex;
-				height: 3.1rem;
+				height: var(--d2l-navigation-immersive-height-main);
 				justify-content: space-between;
 				margin: 0 -7px;
 				max-width: 1230px;
@@ -82,11 +86,19 @@ Polymer-based web component for the immersive navigation component
 				--d2l-navigation-link-back-left-padding: 12px;
 			}
 
+			.d2l-navigation-immersive-spacing {
+				display: block;
+				height: calc(var(--d2l-navigation-immersive-height-main) + 5px);
+				margin: 0;
+				position: unset;
+				width: 100%;
+			}
+
 			.d2l-navigation-shadow-gradient {
 				left: 0;
 				position: fixed;
 				right: 0;
-				top: 3.1rem;
+				top: calc(var(--d2l-navigation-immersive-height-main) + 5px);
 			}
 
 			@media (max-width: 929px) {
@@ -103,10 +115,13 @@ Polymer-based web component for the immersive navigation component
 
 			@media (max-width: 615px) {
 				.d2l-navigation-immersive-container {
-					height: 2.8rem;
+					height: var(--d2l-navigation-immersive-height-responsive);
+				}
+				.d2l-navigation-immersive-spacing {
+					height: calc(var(--d2l-navigation-immersive-height-responsive) + 5px);
 				}
 				.d2l-navigation-shadow-gradient {
-					top: 2.8rem;
+					top: calc(var(--d2l-navigation-immersive-height-responsive) + 5px);
 				}
 				.d2l-navigation-immersive-middle {
 					margin: 0 18px;
@@ -137,6 +152,7 @@ Polymer-based web component for the immersive navigation component
 				</div>
 			</d2l-navigation>
 		</div>
+		<div class="d2l-navigation-immersive-spacing"></div>
 		<div class="d2l-navigation-shadow-gradient"></div>
 	</template>
 	<script>

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots.html
@@ -16,10 +16,12 @@
 			<style is="custom-style" include="demo-pages-shared-styles">
 				body {
 					background-color: pink;
+					padding: 0;
 				}
 				demo-snippet {
 					--demo-snippet-demo: {
 						background-color: transparent;
+						padding: 0;
 					}
 				}
 			</style>
@@ -35,7 +37,7 @@
 				overflow-x: hidden;
 			}
 			.page-contents {
-				margin-top: 3rem;
+				margin: 0 20px;
 			}
 		</style>
 	</head>
@@ -54,7 +56,7 @@
 						</div>
 					</d2l-navigation-immersive>
 					<div class="page-contents">
-						<p>Page Contents</p>
+						<p>First Item in Page Content</p>
 						<p>Page Contents</p>
 						<p>Page Contents</p>
 						<p>Page Contents</p>

--- a/demo/navigation-immersive-demos/navigation-immersive-no-middle-slot.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-no-middle-slot.html
@@ -12,9 +12,13 @@
 		<link rel="import" href="../../d2l-navigation-immersive.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles">
+				body {
+					padding: 0;
+				}
 				demo-snippet {
 					--demo-snippet-demo: {
 						background-color: transparent;
+						padding: 0;
 					}
 				}
 			</style>
@@ -30,7 +34,7 @@
 				overflow-x: hidden;
 			}
 			.page-contents {
-				margin-top: 3rem;
+				margin: 0 20px;
 			}
 		</style>
 	</head>
@@ -44,7 +48,7 @@
 						</div>
 					</d2l-navigation-immersive>
 					<div class="page-contents">
-						<p>Page Contents</p>
+						<p>First Item in Page Content</p>
 						<p>Page Contents</p>
 						<p>Page Contents</p>
 						<p>Page Contents</p>

--- a/demo/navigation-immersive-demos/navigation-immersive-no-slots.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-no-slots.html
@@ -11,9 +11,13 @@
 		<link rel="import" href="../../d2l-navigation-immersive.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles">
+				body {
+					padding: 0;
+				}
 				demo-snippet {
 					--demo-snippet-demo: {
 						background-color: transparent;
+						padding: 0;
 					}
 				}
 			</style>
@@ -29,7 +33,7 @@
 				overflow-x: hidden;
 			}
 			.page-contents {
-				margin-top: 3rem;
+				margin: 0 20px;
 			}
 		</style>
 	</head>
@@ -40,7 +44,7 @@
 					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
 					</d2l-navigation-immersive>
 					<div class="page-contents">
-						<p>Page Contents</p>
+						<p>First Item in Page Content</p>
 						<p>Page Contents</p>
 						<p>Page Contents</p>
 						<p>Page Contents</p>

--- a/test/navigation-immersive.html
+++ b/test/navigation-immersive.html
@@ -14,12 +14,12 @@
 				<d2l-navigation-immersive></d2l-navigation-immersive>
 			</template>
 		</test-fixture>
-		<test-fixture id="back-link">
+		<test-fixture id="backLink">
 			<template strip-whitespace>
 				<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L"></d2l-navigation-immersive>
 			</template>
 		</test-fixture>
-		<test-fixture id="middle-slot-with-content">
+		<test-fixture id="middleSlotWithContent">
 			<template strip-whitespace>
 				<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
 					<div slot="middle">
@@ -30,11 +30,8 @@
 		</test-fixture>
 		<script>
 			suite('d2l-navigation-immersive', function() {
-				var nav;
-				setup(function() {
-					nav = fixture('empty');
-				});
 				test('instantiating the element works', function() {
+					var nav = fixture('empty');
 					assert.equal(nav.is, 'd2l-navigation-immersive');
 
 					var margin = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-margin');
@@ -59,6 +56,7 @@
 				});
 
 				test('hidden class applied when element is resized', function(done) {
+					var nav = fixture('empty');
 					nav._onMiddleResize();
 
 					flush(function() {
@@ -71,15 +69,13 @@
 			});
 
 			suite('d2l-navigation-immersive with back link', function() {
-				var nav;
-				setup(function() {
-					nav = fixture('back-link');
-				});
 				test('back link initializes correctly', function() {
+					var nav = fixture('backLink');
 					assert.equal(nav.backLinkHref, 'https://www.d2l.com');
 					assert.equal(nav.backLinkText, 'Back to D2L');
 				});
 				test('back link values updates correctly', function() {
+					var nav = fixture('backLink');
 					var newHref = 'https://www.nfl.com';
 					var newText = 'Back to da NFL';
 					nav.setAttribute('back-link-href', newHref);
@@ -91,7 +87,7 @@
 
 			suite('d2l-navigation-immersive with content in middle slot', function() {
 				test('hidden class not present when middle slot has content', function() {
-					var nav = fixture('middle-slot-with-content');
+					var nav = fixture('middleSlotWithContent');
 
 					var hiddenMiddle = Polymer.dom(nav.root).querySelector('[class*=\'d2l-navigation-immersive-middle-hidden\']');
 					expect(hiddenMiddle).to.be.null;

--- a/test/navigation-immersive.html
+++ b/test/navigation-immersive.html
@@ -14,12 +14,12 @@
 				<d2l-navigation-immersive></d2l-navigation-immersive>
 			</template>
 		</test-fixture>
-		<test-fixture id="backLink">
+		<test-fixture id="back-link">
 			<template strip-whitespace>
 				<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L"></d2l-navigation-immersive>
 			</template>
 		</test-fixture>
-		<test-fixture id="middleSlotWithContent">
+		<test-fixture id="middle-slot-with-content">
 			<template strip-whitespace>
 				<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
 					<div slot="middle">
@@ -30,8 +30,11 @@
 		</test-fixture>
 		<script>
 			suite('d2l-navigation-immersive', function() {
+				var nav;
+				setup(function() {
+					nav = fixture('empty');
+				});
 				test('instantiating the element works', function() {
-					var nav = fixture('empty');
 					assert.equal(nav.is, 'd2l-navigation-immersive');
 
 					var margin = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-margin');
@@ -56,7 +59,6 @@
 				});
 
 				test('hidden class applied when element is resized', function(done) {
-					var nav = fixture('empty');
 					nav._onMiddleResize();
 
 					flush(function() {
@@ -69,13 +71,15 @@
 			});
 
 			suite('d2l-navigation-immersive with back link', function() {
+				var nav;
+				setup(function() {
+					nav = fixture('back-link');
+				});
 				test('back link initializes correctly', function() {
-					var nav = fixture('backLink');
 					assert.equal(nav.backLinkHref, 'https://www.d2l.com');
 					assert.equal(nav.backLinkText, 'Back to D2L');
 				});
 				test('back link values updates correctly', function() {
-					var nav = fixture('backLink');
 					var newHref = 'https://www.nfl.com';
 					var newText = 'Back to da NFL';
 					nav.setAttribute('back-link-href', newHref);
@@ -87,7 +91,7 @@
 
 			suite('d2l-navigation-immersive with content in middle slot', function() {
 				test('hidden class not present when middle slot has content', function() {
-					var nav = fixture('middleSlotWithContent');
+					var nav = fixture('middle-slot-with-content');
 
 					var hiddenMiddle = Polymer.dom(nav.root).querySelector('[class*=\'d2l-navigation-immersive-middle-hidden\']');
 					expect(hiddenMiddle).to.be.null;


### PR DESCRIPTION
Right now, consumers need to add a margin to the top of their page when using the immersive nav, so the start of the content is visible. Instead of having them worry about it (and the responsive rules), I'm adding a div here to take up the same amount of space as the header.  This will only work if the immersive nav element is the first visual element on the page, but that _should_ always be the case anyways and I'm good with enforcing that for now.