### PR TITLE
Remove check for elements with height less than 1

### DIFF
--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -187,7 +187,6 @@ Polymer-based web component for the immersive navigation component
 				} else {
 					slotContent = D2L.Dom.getComposedChildren(middleContainer);
 				}
-
 				if (!slotContent || slotContent.length === 0) {
 					fastdom.mutate(function() {
 						// nothing in middle
@@ -197,22 +196,17 @@ Polymer-based web component for the immersive navigation component
 				}
 
 				var elementInSlot = slotContent[0];
-
-				fastdom.measure(function() {
-					var slotHeight = elementInSlot.clientHeight;
-
-					if (!elementInSlot || slotHeight < 1) {
-						fastdom.mutate(function() {
-							// nothing in middle
-							middleContainer.classList.add('d2l-navigation-immersive-middle-hidden');
-						});
-					} else if (slotHeight > 0) {
-						fastdom.mutate(function() {
-							// stuff in middle
-							middleContainer.classList.remove('d2l-navigation-immersive-middle-hidden');
-						});
-					}
-				});
+				if (!elementInSlot) {
+					fastdom.mutate(function() {
+						// nothing in middle
+						middleContainer.classList.add('d2l-navigation-immersive-middle-hidden');
+					});
+				} else {
+					fastdom.mutate(function() {
+						// stuff in middle
+						middleContainer.classList.remove('d2l-navigation-immersive-middle-hidden');
+					});
+				}
 			}
 		});
 	</script>


### PR DESCRIPTION
Resolves [DE32394](https://rally1.rallydev.com/#/42960320374d/detail/defect/277379116328?fdp=true)

In light of this comment:
https://github.com/BrightspaceUI/card/blob/master/d2l-card.js#L284

I don't think we need to check for the height less than 1 since we're not making use of `box-sizing: border-box;`

@dbatiste Can you please confirm that my understanding is correct? Thank you!