### PR TITLE
DE32394 - Fix Hiding of Middle Slot

### DIFF
--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-fastdom-import/fastdom.html">
-<link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
 <link rel="import" href="../d2l-resize-observer-polyfill-import/resize-observer.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="d2l-navigation.html">
@@ -78,8 +77,12 @@ Polymer-based web component for the immersive navigation component
 				width: 100%
 			}
 
+			.d2l-navigation-immersive-middle-observer {
+				height: auto;
+			}
+
 			.d2l-navigation-immersive-middle-hidden {
-				display: none;
+				visibility: hidden;
 			}
 
 			d2l-navigation-link-back {
@@ -140,7 +143,9 @@ Polymer-based web component for the immersive navigation component
 							</slot>
 						</div>
 						<div class="d2l-navigation-immersive-middle">
-				    		<slot name="middle"></slot>
+							<div class="d2l-navigation-immersive-middle-observer">
+				    			<slot name="middle"></slot>
+							</div>
 						</div>
 						<div class="d2l-navigation-immersive-right">
 			    			<slot name="right"></slot>
@@ -172,60 +177,37 @@ Polymer-based web component for the immersive navigation component
 			},
 
 			attached: function() {
-				var middle = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle');
+				var middle = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle-observer');
 				this._middleObserver = new ResizeObserver(this._onMiddleResize);
 				this._middleObserver.observe(middle);
 			},
 
 			detached: function() {
-				var middle = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle');
+				var middle = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle-observer');
 				if (this._middleObserver) {
 					this._middleObserver.unobserve(middle);
 				}
 			},
 
-			_onMiddleResize: function() {
-				var middleContainer = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle');
-
-				fastdom.measure(function() {
-					if (middleContainer.clientHeight < 1) {
-						return;
-					}
-				});
-
-				var slotElement = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle > slot');
-				var slotContent = [];
-				if (slotElement) {
-					slotContent = D2L.Dom.getComposedChildren(slotElement);
-				} else {
-					slotContent = D2L.Dom.getComposedChildren(middleContainer);
+			_onMiddleResize: function(entries) {
+				if (!entries || entries.length === 0) {
+					return;
 				}
 
-				if (!slotContent || slotContent.length === 0) {
+				var entry = entries[0];
+				var middleContainer = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle');
+
+				if (entry.contentRect.height > 0) {
+					fastdom.mutate(function() {
+						// stuff in middle
+						middleContainer.classList.remove('d2l-navigation-immersive-middle-hidden');
+					});
+				} else if (entry.contentRect.height === 0) {
 					fastdom.mutate(function() {
 						// nothing in middle
 						middleContainer.classList.add('d2l-navigation-immersive-middle-hidden');
 					});
-					return;
 				}
-
-				var elementInSlot = slotContent[0];
-
-				fastdom.measure(function() {
-					var slotHeight = elementInSlot.clientHeight;
-
-					if (!elementInSlot || slotHeight < 1) {
-						fastdom.mutate(function() {
-							// nothing in middle
-							middleContainer.classList.add('d2l-navigation-immersive-middle-hidden');
-						});
-					} else if (slotHeight > 0) {
-						fastdom.mutate(function() {
-							// stuff in middle
-							middleContainer.classList.remove('d2l-navigation-immersive-middle-hidden');
-						});
-					}
-				});
 			}
 		});
 	</script>

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -197,16 +197,20 @@ Polymer-based web component for the immersive navigation component
 				var entry = entries[0];
 				var middleContainer = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle');
 
-				if (entry.contentRect.height > 0) {
-					fastdom.mutate(function() {
-						// stuff in middle
-						middleContainer.classList.remove('d2l-navigation-immersive-middle-hidden');
-					});
-				} else if (entry.contentRect.height === 0) {
-					fastdom.mutate(function() {
-						// nothing in middle
-						middleContainer.classList.add('d2l-navigation-immersive-middle-hidden');
-					});
+				if (entry.contentRect.height < 1) {
+					// nothing in middle
+					if (!middleContainer.classList.contains('d2l-navigation-immersive-middle-hidden')) {
+						fastdom.mutate(function() {
+							middleContainer.classList.add('d2l-navigation-immersive-middle-hidden');
+						});
+					}
+				} else {
+					// stuff in middle
+					if (middleContainer.classList.contains('d2l-navigation-immersive-middle-hidden')) {
+						fastdom.mutate(function() {
+							middleContainer.classList.remove('d2l-navigation-immersive-middle-hidden');
+						});
+					}
 				}
 			}
 		});

--- a/demo/navigation-immersive-demos/navigation-immersive-middle-slot-responsive.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-middle-slot-responsive.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-navigation-immersive demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography-shared-styles.html">
+		<link rel="import" href="../../d2l-navigation-button.html">
+		<link rel="import" href="../../d2l-navigation-button-close.html">
+		<link rel="import" href="../../d2l-navigation-immersive.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles">
+				body {
+					background-color: pink;
+					padding: 0;
+				}
+				demo-snippet {
+					--demo-snippet-demo: {
+						background-color: transparent;
+						padding: 0;
+					}
+				}
+			</style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+			body {
+				overflow-x: hidden;
+			}
+			.page-contents {
+				margin: 0 20px;
+			}
+			@media (max-width: 700px) {
+				.d2l-responsive {
+					display: none;
+				}
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered" style="max-width: 900px;">
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+						<div class="d2l-typography d2l-body-standard d2l-responsive" slot="middle">
+							<p>Economics 101</p>
+						</div>
+						<div slot="right">
+							<d2l-navigation-button text="A button">One Button</d2l-navigation-button>
+							<d2l-navigation-button-close></d2l-navigation-button-close>
+							<d2l-navigation-button text="Another button">Two Button</d2l-navigation-button>
+						</div>
+					</d2l-navigation-immersive>
+					<div class="page-contents">
+						<p>First Item in Page Content</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+					</div>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/navigation-immersive-demos/navigation-immersive-middle-slot-responsive.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-middle-slot-responsive.html
@@ -40,7 +40,7 @@
 				margin: 0 20px;
 			}
 			@media (max-width: 700px) {
-				.d2l-responsive {
+				#middle.d2l-responsive[slot="middle"] {
 					display: none;
 				}
 			}
@@ -51,7 +51,7 @@
 			<demo-snippet>
 				<template strip-whitespace>
 					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
-						<div class="d2l-typography d2l-body-standard d2l-responsive" slot="middle">
+						<div id="middle" class="d2l-typography d2l-body-standard d2l-responsive" slot="middle">
 							<p>Economics 101</p>
 						</div>
 						<div slot="right">

--- a/demo/navigation-immersive.html
+++ b/demo/navigation-immersive.html
@@ -33,6 +33,9 @@
 			<h3>d2l-navigation-immersive</h3>
 			<iframe src="./navigation-immersive-demos/navigation-immersive-all-slots.html"></iframe>
 
+			<h3>d2l-navigation-immersive (consumer hides the middle slot at 700px)</h3>
+			<iframe src="./navigation-immersive-demos/navigation-immersive-middle-slot-responsive.html"></iframe>
+
 			<h3>d2l-navigation-immersive (no middle slot)</h3>
 			<iframe src="./navigation-immersive-demos/navigation-immersive-no-middle-slot.html"></iframe>
 

--- a/test/navigation-immersive.html
+++ b/test/navigation-immersive.html
@@ -22,17 +22,40 @@
 		<test-fixture id="middle-slot-with-content">
 			<template strip-whitespace>
 				<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
-					<div slot="middle">
+					<div slot="middle" id="middle">
+						<p>Economics 101</p>
+					</div>
+				</d2l-navigation-immersive>
+			</template>
+		</test-fixture>
+		<test-fixture id="middle-slot-with-hidden-content">
+			<template strip-whitespace>
+				<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+					<div slot="middle" id="middle-hidden" style="display: none;">
 						<p>Economics 101</p>
 					</div>
 				</d2l-navigation-immersive>
 			</template>
 		</test-fixture>
 		<script>
+			var raf = function(cb) {
+				fastdom.measure(function() {
+					fastdom.mutate(function() {
+						requestAnimationFrame(function() {
+							requestAnimationFrame(function() {
+								requestAnimationFrame(function() {
+									cb();
+								});
+							});
+						});
+					});
+				});
+			};
 			suite('d2l-navigation-immersive', function() {
 				var nav;
-				setup(function() {
+				setup(function(done) {
 					nav = fixture('empty');
+					raf(done);
 				});
 				test('instantiating the element works', function() {
 					assert.equal(nav.is, 'd2l-navigation-immersive');
@@ -58,22 +81,17 @@
 					assert.equal(right.tagName, 'DIV');
 				});
 
-				test('hidden class applied when element is resized', function(done) {
-					nav._onMiddleResize();
-
-					flush(function() {
-						var hiddenMiddle = Polymer.dom(nav.root).querySelector('[class*=\'d2l-navigation-immersive-middle-hidden\']');
+				test('hidden class applied when element has no middle slot content', function() {
+						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
 						expect(hiddenMiddle).to.not.be.null;
-
-						done();
-					});
 				});
 			});
 
 			suite('d2l-navigation-immersive with back link', function() {
 				var nav;
-				setup(function() {
+				setup(function(done) {
 					nav = fixture('back-link');
+					raf(done);
 				});
 				test('back link initializes correctly', function() {
 					assert.equal(nav.backLinkHref, 'https://www.d2l.com');
@@ -90,11 +108,52 @@
 			});
 
 			suite('d2l-navigation-immersive with content in middle slot', function() {
+				var nav;
+				setup(function(done) {
+					nav = fixture('middle-slot-with-content');
+					raf(done);
+				});
 				test('hidden class not present when middle slot has content', function() {
-					var nav = fixture('middle-slot-with-content');
-
-					var hiddenMiddle = Polymer.dom(nav.root).querySelector('[class*=\'d2l-navigation-immersive-middle-hidden\']');
+					var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
 					expect(hiddenMiddle).to.be.null;
+				});
+				test('hidden class applied when content in middle slot is hidden', function(done) {
+					var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+					expect(hiddenMiddle).to.be.null;
+
+					var middleContent = Polymer.dom(nav).querySelector("#middle");
+					middleContent.style.display = 'none';
+
+					raf(function() {
+						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+						expect(hiddenMiddle).to.not.be.null;
+						done();
+					});
+				});
+
+				suite('d2l-navigation-immersive with hidden content in middle slot', function() {
+					var nav;
+					setup(function(done) {
+						nav = fixture('middle-slot-with-hidden-content');
+						raf(done);
+					});
+					test('hidden class present when middle slot has hidden content', function() {
+						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+						expect(hiddenMiddle).to.not.be.null;
+					});
+					test('hidden class remvoed when content in middle slot is re-shown', function(done) {
+						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+						expect(hiddenMiddle).to.not.be.null;
+
+						var middleContent = Polymer.dom(nav).querySelector("#middle-hidden");
+						middleContent.style.display = 'block';
+
+						raf(function() {
+							var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+							expect(hiddenMiddle).to.be.null;
+							done();
+						});
+					});
 				});
 			});
 		</script>

--- a/test/navigation-immersive.html
+++ b/test/navigation-immersive.html
@@ -44,7 +44,9 @@
 						requestAnimationFrame(function() {
 							requestAnimationFrame(function() {
 								requestAnimationFrame(function() {
-									cb();
+									window.setTimeout(function() {
+										cb();
+									}, 200);
 								});
 							});
 						});

--- a/test/navigation-immersive.html
+++ b/test/navigation-immersive.html
@@ -82,8 +82,8 @@
 				});
 
 				test('hidden class applied when element has no middle slot content', function() {
-						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
-						expect(hiddenMiddle).to.not.be.null;
+					var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+					expect(hiddenMiddle).to.not.be.null;
 				});
 			});
 
@@ -121,7 +121,7 @@
 					var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
 					expect(hiddenMiddle).to.be.null;
 
-					var middleContent = Polymer.dom(nav).querySelector("#middle");
+					var middleContent = Polymer.dom(nav).querySelector('#middle');
 					middleContent.style.display = 'none';
 
 					raf(function() {
@@ -141,11 +141,11 @@
 						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
 						expect(hiddenMiddle).to.not.be.null;
 					});
-					test('hidden class remvoed when content in middle slot is re-shown', function(done) {
+					test('hidden class removed when content in middle slot is re-shown', function(done) {
 						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
 						expect(hiddenMiddle).to.not.be.null;
 
-						var middleContent = Polymer.dom(nav).querySelector("#middle-hidden");
+						var middleContent = Polymer.dom(nav).querySelector('#middle-hidden');
 						middleContent.style.display = 'block';
 
 						raf(function() {


### PR DESCRIPTION
Alternative to the fix we were trying to get working in https://github.com/BrightspaceUI/navigation/pull/48.  Edge is refusing to cooperate with `clientHeight` on a `slot`, so this is a bit of a redesign of the whole system.  We now have a div in the `d2l-navigation-immersive-middle` div that is only used to tell us the height of the slot's contents, and the `ResizeObserver` watches that instead.  We can use the `entries` array of the `ResizeObserver` now (before we couldn't because the `d2l-navigation-immersive-middle` had `height: 100%`, but we are now watching the new `div` with `height: auto`), so the code in `_onMiddleResize` can be simplified.

Still need to check the functionality and the tests on every browser!  But wanted to get the review up and sauce running.