### PR TITLE
Dbatiste/fix nav button focus

### DIFF
--- a/d2l-navigation-button.html
+++ b/d2l-navigation-button.html
@@ -15,6 +15,12 @@ Polymer-based web component for buttons used in the navigational header.
 <dom-module id="d2l-navigation-button">
 	<template strip-whitespace>
 		<style is="custom-style" include="d2l-navigation-highlight-styles">
+
+			:host {
+				display: inline-block;
+				height: 100%;
+			}
+
 			:host([disabled]) button {
 				@apply --d2l-navigation-highlight-disabled;
 			}

--- a/d2l-navigation-button.html
+++ b/d2l-navigation-button.html
@@ -18,6 +18,11 @@ Polymer-based web component for buttons used in the navigational header.
 			:host([disabled]) button {
 				@apply --d2l-navigation-highlight-disabled;
 			}
+
+			:host button ::slotted(*) {
+				pointer-events: none;
+			}
+
 			:host(:not([disabled])) button:hover,
 			:host(:not([disabled])) button:focus,
 			/* ::slotted styles for Polymer 2.0 */

--- a/d2l-navigation-button.html
+++ b/d2l-navigation-button.html
@@ -21,51 +21,56 @@ Polymer-based web component for buttons used in the navigational header.
 				height: 100%;
 			}
 
-			:host([disabled]) button {
-				@apply --d2l-navigation-highlight-disabled;
-			}
-
 			:host button ::slotted(*) {
 				pointer-events: none;
 			}
 
-			:host(:not([disabled])) button:hover,
-			:host(:not([disabled])) button:focus,
+			:host button:hover,
+			:host button:focus,
 			/* ::slotted styles for Polymer 2.0 */
-			:host(:not([disabled])) button:hover ::slotted(*),
-			:host(:not([disabled])) button:focus ::slotted(*)
-			{
+			:host button:hover ::slotted(*),
+			:host button:focus ::slotted(*) {
 				@apply --d2l-navigation-highlight-base-hover-focus;
 			}
+
 			/*
 				::slotted styles for Polymer 1.0; styling all slotted children needs
 				to be applied explicitely.
 				This cannot be combined with the style block above, as this is not
 				valid in 2.0 and as such the entire block gets ignored.
 			*/
-			:host(:not([disabled])) button:hover ::slotted(*) *,
-			:host(:not([disabled])) button:focus ::slotted(*) *
-			{
+			:host button:hover ::slotted(*) *,
+			:host button:focus ::slotted(*) * {
 				@apply --d2l-navigation-highlight-base-hover-focus;
 			}
-			:host(:not([disabled])) button:hover .d2l-navigation-button-top-border,
-			:host(:not([disabled])) button:focus .d2l-navigation-button-top-border {
+
+			:host button:hover .d2l-navigation-button-top-border,
+			:host button:focus .d2l-navigation-button-top-border {
 				@apply --d2l-navigation-highlight-border-hover-focus;
 			}
+
 			button {
 				@apply --d2l-navigation-highlight-base;
 				font-family: inherit;
 			}
+
 			.d2l-navigation-button-top-border {
 				@apply --d2l-navigation-highlight-border;
 			}
+
 			.d2l-offscreen-description {
 				@apply --d2l-offscreen;
 			}
+
 			:host-context([dir="rtl"]) .d2l-offscreen-description,
 			:host(:dir(rtl)) .d2l-offscreen-description {
 				@apply --d2l-offscreen-rtl;
 			}
+
+			:host([disabled]) button {
+				@apply --d2l-navigation-highlight-disabled;
+			}
+
 		</style>
 		<button
 			aria-describedby$="[[_ariaDescriptionId]]"

--- a/demo/d2l-navigation-button.html
+++ b/demo/d2l-navigation-button.html
@@ -36,6 +36,12 @@
 						.button-holder {
 							height: 90px;
 						}
+
+						.button-holder :first-child {
+							margin-left: 0;
+						}
+
+						d2l-navigation-button,
 						d2l-navigation-button-notification-icon,
 						d2l-navigation-button-image,
 						d2l-navigation-button-close {


### PR DESCRIPTION
* Added `pointer-events: none;` to slotted content to address button in shadow-dom not getting focus when clicked.

* reorganized and simplified selectors.
