### PR TITLE
US103275 - Adjustments to the design when the right slot is empty

### DIFF
--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -92,8 +92,8 @@ Polymer-based web component for the immersive navigation component
 				border-right: none;
 			}
 
-			.d2l-navigation-immersive-middle-observer,
-			.d2l-navigation-immersive-right-observer {
+			div.d2l-navigation-immersive-middle-observer,
+			div.d2l-navigation-immersive-right-observer {
 				height: auto;
 			}
 

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -48,7 +48,19 @@ Polymer-based web component for the immersive navigation component
 			.d2l-navigation-immersive-left ::slotted(*),
 			.d2l-navigation-immersive-middle ::slotted(*),
 			.d2l-navigation-immersive-right ::slotted(*) {
-				height: 100%;
+				height: var(--d2l-navigation-immersive-height-main);
+			}
+
+			/*
+				::slotted styles for Polymer 1.0; styling all slotted children needs
+				to be applied explicitely.
+				This cannot be combined with the style block above, as this is not
+				valid in 2.0 and as such the entire block gets ignored.
+			*/
+			.d2l-navigation-immersive-left ::slotted(*) > *,
+			.d2l-navigation-immersive-middle ::slotted(*) > *,
+			.d2l-navigation-immersive-right ::slotted(*) > * {
+				height: var(--d2l-navigation-immersive-height-main);
 			}
 
 			.d2l-navigation-immersive-left {
@@ -115,6 +127,22 @@ Polymer-based web component for the immersive navigation component
 			@media (max-width: 615px) {
 				.d2l-navigation-immersive-container {
 					height: var(--d2l-navigation-immersive-height-responsive);
+				}
+				.d2l-navigation-immersive-left ::slotted(*),
+				.d2l-navigation-immersive-middle ::slotted(*),
+				.d2l-navigation-immersive-right ::slotted(*) {
+					height: var(--d2l-navigation-immersive-height-responsive);
+				}
+				/*
+					::slotted styles for Polymer 1.0; styling all slotted children needs
+					to be applied explicitely.
+					This cannot be combined with the style block above, as this is not
+					valid in 2.0 and as such the entire block gets ignored.
+				*/
+				.d2l-navigation-immersive-left ::slotted(*) > *,
+				.d2l-navigation-immersive-middle ::slotted(*) > *,
+				.d2l-navigation-immersive-right ::slotted(*) > * {
+					height: var(--d2l-navigation-immersive-height-main);
 				}
 				.d2l-navigation-immersive-spacing {
 					height: calc(var(--d2l-navigation-immersive-height-responsive) + 5px);

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -88,7 +88,12 @@ Polymer-based web component for the immersive navigation component
 				width: 100%;
 			}
 
-			.d2l-navigation-immersive-middle-observer {
+			.d2l-navigation-immersive-middle.d2l-navigation-immersive-middle-no-right-border {
+				border-right: none;
+			}
+
+			.d2l-navigation-immersive-middle-observer,
+			.d2l-navigation-immersive-right-observer {
 				height: auto;
 			}
 
@@ -169,13 +174,15 @@ Polymer-based web component for the immersive navigation component
 								<d2l-navigation-link-back text="[[backLinkText]]" href="[[backLinkHref]]"></d2l-navigation-link-back>
 							</slot>
 						</div>
-						<div class="d2l-navigation-immersive-middle">
+						<div class="d2l-navigation-immersive-middle d2l-navigation-immersive-middle-no-right-border">
 							<div class="d2l-navigation-immersive-middle-observer">
 				    			<slot name="middle"></slot>
 							</div>
 						</div>
 						<div class="d2l-navigation-immersive-right">
-			    			<slot name="right"></slot>
+							<div class="d2l-navigation-immersive-right-observer">
+								<slot name="right"></slot>
+							</div>
 						</div>
 					</div>
 				</div>
@@ -201,12 +208,17 @@ Polymer-based web component for the immersive navigation component
 
 			ready: function() {
 				this._onMiddleResize = this._onMiddleResize.bind(this);
+				this._onRightResize = this._onRightResize.bind(this);
 			},
 
 			attached: function() {
 				var middle = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle-observer');
 				this._middleObserver = new ResizeObserver(this._onMiddleResize);
 				this._middleObserver.observe(middle);
+
+				var right = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-right-observer');
+				this._rightObserver = new ResizeObserver(this._onRightResize);
+				this._rightObserver.observe(right);
 			},
 
 			detached: function() {
@@ -214,28 +226,41 @@ Polymer-based web component for the immersive navigation component
 				if (this._middleObserver) {
 					this._middleObserver.unobserve(middle);
 				}
+
+				var right = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-right-observer');
+				if (this._rightObserver) {
+					this._rightObserver.unobserve(right);
+				}
 			},
 
 			_onMiddleResize: function(entries) {
+				this._onResize(entries, '.d2l-navigation-immersive-middle', 'd2l-navigation-immersive-middle-hidden');
+			},
+
+			_onRightResize: function(entries) {
+				this._onResize(entries, '.d2l-navigation-immersive-middle', 'd2l-navigation-immersive-middle-no-right-border');
+			},
+
+			_onResize: function(entries, slotContainerQuerySelector, containerClass) {
 				if (!entries || entries.length === 0) {
 					return;
 				}
 
 				var entry = entries[0];
-				var middleContainer = Polymer.dom(this.root).querySelector('.d2l-navigation-immersive-middle');
+				var container = Polymer.dom(this.root).querySelector(slotContainerQuerySelector);
 
 				if (entry.contentRect.height < 1) {
-					// nothing in middle
-					if (!middleContainer.classList.contains('d2l-navigation-immersive-middle-hidden')) {
+					// nothing in slot
+					if (!container.classList.contains(containerClass)) {
 						fastdom.mutate(function() {
-							middleContainer.classList.add('d2l-navigation-immersive-middle-hidden');
+							container.classList.add(containerClass);
 						});
 					}
 				} else {
-					// stuff in middle
-					if (middleContainer.classList.contains('d2l-navigation-immersive-middle-hidden')) {
+					// stuff in slot
+					if (container.classList.contains(containerClass)) {
 						fastdom.mutate(function() {
-							middleContainer.classList.remove('d2l-navigation-immersive-middle-hidden');
+							container.classList.remove(containerClass);
 						});
 					}
 				}

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -42,7 +42,6 @@ Polymer-based web component for the immersive navigation component
 				height: var(--d2l-navigation-immersive-height-main);
 				justify-content: space-between;
 				margin: 0 -7px;
-				max-width: 1230px;
 				overflow: hidden;
 			}
 
@@ -74,7 +73,7 @@ Polymer-based web component for the immersive navigation component
 				flex: 0 1 auto;
 				margin: 0 24px;
 				padding: 0 24px;
-				width: 100%
+				width: 100%;
 			}
 
 			.d2l-navigation-immersive-middle-observer {

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots.html
@@ -39,6 +39,10 @@
 			.page-contents {
 				margin: 0 20px;
 			}
+			div[slot="middle"]#middle {
+				display: table-cell;
+				vertical-align: middle;
+			}
 		</style>
 	</head>
 	<body unresolved class="d2l-typography">
@@ -46,8 +50,8 @@
 			<demo-snippet>
 				<template strip-whitespace>
 					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
-						<div class="d2l-typography d2l-body-standard" slot="middle">
-							<p>Economics 101</p>
+						<div id="middle" class="d2l-typography d2l-body-standard" slot="middle">
+							Economics 101
 						</div>
 						<div slot="right">
 							<d2l-navigation-button text="A button">One Button</d2l-navigation-button>

--- a/demo/navigation-immersive-demos/navigation-immersive-middle-slot-responsive.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-middle-slot-responsive.html
@@ -39,6 +39,10 @@
 			.page-contents {
 				margin: 0 20px;
 			}
+			div[slot="middle"]#middle {
+				display: table-cell;
+				vertical-align: middle;
+			}
 			@media (max-width: 700px) {
 				#middle.d2l-responsive[slot="middle"] {
 					display: none;
@@ -52,7 +56,7 @@
 				<template strip-whitespace>
 					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
 						<div id="middle" class="d2l-typography d2l-body-standard d2l-responsive" slot="middle">
-							<p>Economics 101</p>
+							Economics 101
 						</div>
 						<div slot="right">
 							<d2l-navigation-button text="A button">One Button</d2l-navigation-button>

--- a/demo/navigation-immersive-demos/navigation-immersive-no-right-slot.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-no-right-slot.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-navigation-immersive demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../d2l-navigation-button.html">
+		<link rel="import" href="../../d2l-navigation-immersive.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles">
+				body {
+					padding: 0;
+				}
+				demo-snippet {
+					--demo-snippet-demo: {
+						background-color: transparent;
+						padding: 0;
+					}
+				}
+			</style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+			}
+			body {
+				overflow-x: hidden;
+			}
+			.page-contents {
+				margin: 0 20px;
+			}
+			div[slot="middle"]#middle {
+				display: table-cell;
+				vertical-align: middle;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered" style="max-width: 900px;">
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+						<div id="middle" class="d2l-typography d2l-body-standard" slot="middle">
+							Economics 101
+						</div>
+					</d2l-navigation-immersive>
+					<div class="page-contents">
+						<p>First Item in Page Content</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+					</div>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/navigation-immersive-demos/navigation-immersive-responsive-slot-hiding.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-responsive-slot-hiding.html
@@ -43,6 +43,11 @@
 				display: table-cell;
 				vertical-align: middle;
 			}
+			@media (max-width: 900px) {
+				#right.d2l-responsive[slot="right"] {
+					display: none;
+				}
+			}
 			@media (max-width: 700px) {
 				#middle.d2l-responsive[slot="middle"] {
 					display: none;
@@ -58,7 +63,7 @@
 						<div id="middle" class="d2l-typography d2l-body-standard d2l-responsive" slot="middle">
 							Economics 101
 						</div>
-						<div slot="right">
+						<div id="right" class="d2l-responsive" slot="right">
 							<d2l-navigation-button text="A button">One Button</d2l-navigation-button>
 							<d2l-navigation-button-close></d2l-navigation-button-close>
 							<d2l-navigation-button text="Another button">Two Button</d2l-navigation-button>

--- a/demo/navigation-immersive.html
+++ b/demo/navigation-immersive.html
@@ -33,8 +33,8 @@
 			<h3>d2l-navigation-immersive</h3>
 			<iframe src="./navigation-immersive-demos/navigation-immersive-all-slots.html"></iframe>
 
-			<h3>d2l-navigation-immersive (consumer hides the middle slot at 700px)</h3>
-			<iframe src="./navigation-immersive-demos/navigation-immersive-middle-slot-responsive.html"></iframe>
+			<h3>d2l-navigation-immersive (consumer hides the right slot at 900px and the middle slot at 700px)</h3>
+			<iframe src="./navigation-immersive-demos/navigation-immersive-responsive-slot-hiding.html"></iframe>
 
 			<h3>d2l-navigation-immersive (no middle slot)</h3>
 			<iframe src="./navigation-immersive-demos/navigation-immersive-no-middle-slot.html"></iframe>

--- a/demo/navigation-immersive.html
+++ b/demo/navigation-immersive.html
@@ -39,6 +39,9 @@
 			<h3>d2l-navigation-immersive (no middle slot)</h3>
 			<iframe src="./navigation-immersive-demos/navigation-immersive-no-middle-slot.html"></iframe>
 
+			<h3>d2l-navigation-immersive (no right slot)</h3>
+			<iframe src="./navigation-immersive-demos/navigation-immersive-no-right-slot.html"></iframe>
+
 			<h3>d2l-navigation-immersive (no middle slot, no right slot)</h3>
 			<iframe src="./navigation-immersive-demos/navigation-immersive-no-slots.html"></iframe>
 		</div>

--- a/test/navigation-immersive.html
+++ b/test/navigation-immersive.html
@@ -37,6 +37,18 @@
 				</d2l-navigation-immersive>
 			</template>
 		</test-fixture>
+		<test-fixture id="middle-and-right-slot-with-content">
+			<template strip-whitespace>
+				<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+					<div slot="middle" id="middle">
+						<p>Economics 101</p>
+					</div>
+					<div slot="right" id="right">
+						<p>ECON101</p>
+					</div>
+				</d2l-navigation-immersive>
+			</template>
+		</test-fixture>
 		<script>
 			var raf = function(cb) {
 				fastdom.measure(function() {
@@ -87,6 +99,11 @@
 					var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
 					expect(hiddenMiddle).to.not.be.null;
 				});
+
+				test('no right border when element has no right slot content', function() {
+					var noRightBorderMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-no-right-border');
+					expect(noRightBorderMiddle).to.not.be.null;
+				});
 			});
 
 			suite('d2l-navigation-immersive with back link', function() {
@@ -109,7 +126,7 @@
 				});
 			});
 
-			suite('d2l-navigation-immersive with content in middle slot', function() {
+			suite('d2l-navigation-immersive with content in middle slot (no right slot)', function() {
 				var nav;
 				setup(function(done) {
 					nav = fixture('middle-slot-with-content');
@@ -118,6 +135,10 @@
 				test('hidden class not present when middle slot has content', function() {
 					var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
 					expect(hiddenMiddle).to.be.null;
+				});
+				test('no right border class is present when right slot has no content', function() {
+					var noRightBorderMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-no-right-border');
+					expect(noRightBorderMiddle).to.not.be.null;
 				});
 				test('hidden class applied when content in middle slot is hidden', function(done) {
 					var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
@@ -153,6 +174,60 @@
 						raf(function() {
 							var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
 							expect(hiddenMiddle).to.be.null;
+							done();
+						});
+					});
+				});
+
+				suite('d2l-navigation-immersive with content in middle slot and right slot', function() {
+					var nav;
+					setup(function(done) {
+						nav = fixture('middle-and-right-slot-with-content');
+						raf(done);
+					});
+					test('hidden class not present when middle slot has content', function() {
+						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+						expect(hiddenMiddle).to.be.null;
+					});
+					test('no right border class not present when right slot has content', function() {
+						var noRightBorderMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-no-right-border');
+						expect(noRightBorderMiddle).to.be.null;
+					});
+					test('hidden class applied when content in middle slot is hidden, and no right border class still not present', function(done) {
+						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+						expect(hiddenMiddle).to.be.null;
+
+						var noRightBorderMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-no-right-border');
+						expect(noRightBorderMiddle).to.be.null;
+
+						var middleContent = Polymer.dom(nav).querySelector('#middle');
+						middleContent.style.display = 'none';
+
+						raf(function() {
+							var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+							expect(hiddenMiddle).to.not.be.null;
+
+							var noRightBorderMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-no-right-border');
+							expect(noRightBorderMiddle).to.be.null;
+							done();
+						});
+					});
+					test('no right border class applied when content in right slot is hidden', function(done) {
+						var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+						expect(hiddenMiddle).to.be.null;
+
+						var noRightBorderMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-no-right-border');
+						expect(noRightBorderMiddle).to.be.null;
+
+						var rightContent = Polymer.dom(nav).querySelector('#right');
+						rightContent.style.display = 'none';
+
+						raf(function() {
+							var hiddenMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-hidden');
+							expect(hiddenMiddle).to.be.null;
+
+							var noRightBorderMiddle = Polymer.dom(nav.root).querySelector('.d2l-navigation-immersive-middle-no-right-border');
+							expect(noRightBorderMiddle).to.not.be.null;
 							done();
 						});
 					});


### PR DESCRIPTION
This is a use case the LE will be using, where the left slot has the back button and the middle slot has a title (until an iterator is eventually added in the future).  Spoke to Jeff G about the design of this and made adjustments accordingly.  The design now looks like this (the right slot takes up no space if it is empty, and the right separator is hidden):
![image](https://user-images.githubusercontent.com/13419300/51122326-9b2fdc00-17e7-11e9-93af-6f0c95db2dab.png)

~Still to do - Fixing and adding tests~ Done