### PR TITLE
supporting a slimmer logo for when there's a title

### DIFF
--- a/d2l-navigation-link-image.html
+++ b/d2l-navigation-link-image.html
@@ -17,9 +17,13 @@ Polymer-based web component for the image link used in the navigational header.
 			}
 			img {
 				vertical-align: middle;
-				border: none;
+				border: none; /* needed for IE10 */
 				max-height: 60px;
 				max-width: 260px;
+			}
+			:host([slim]) img {
+				max-height: 40px;
+				max-width: 173px;
 			}
 			.d2l-navigation-link-image-container {
 				height: 100%;
@@ -41,6 +45,10 @@ Polymer-based web component for the image link used in the navigational header.
 				},
 				href: {
 					type: String
+				},
+				slim: {
+					type: Boolean,
+					value: false
 				},
 				text: {
 					type: String

--- a/d2l-navigation-link-image.html
+++ b/d2l-navigation-link-image.html
@@ -47,6 +47,7 @@ Polymer-based web component for the image link used in the navigational header.
 					type: String
 				},
 				slim: {
+					reflectToAttribute: true,
 					type: Boolean,
 					value: false
 				},


### PR DESCRIPTION
Replaces [this code in BSI](https://github.com/Brightspace/brightspace-integration/blob/master/sass/navigation/logo.scss#L15), which wasn't working with shadow DOM anyway.