### PR TITLE
Align Immersive navigation max-width to content max-width

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyf
 Then add the `d2l-navigation-immersive`, providing values for the `backLinkHref` & `backLinkText`. Additionally, you may override any of the 3 slots (`left`, `middle`, `right`).
 Please note that overridding the `left` slot will prevent the Back link from displaying. This should only be done in very specialized cases.
 
+`d2l-navigation-immersive` can optionally have a max width set to match your content.  Simply set the `--d2l-navigation-immersive-content-max-width` css variable to your desired width.
+
 <!---
 ```
 <custom-element-demo>

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -38,11 +38,11 @@ Polymer-based web component for the immersive navigation component
 			}
 
 			.d2l-navigation-immersive-container {
-				margin: 0 auto;
-				max-width: var(--d2l-navigation-immersive-content-max-width, 100%);
 				display: flex;
 				height: var(--d2l-navigation-immersive-height-main);
 				justify-content: space-between;
+				margin: 0 auto;
+				max-width: var(--d2l-navigation-immersive-content-max-width, 100%);
 				overflow: hidden;
 			}
 

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -34,6 +34,8 @@ Polymer-based web component for the immersive navigation component
 				border-bottom: 1px solid var(--d2l-color-mica);
 			}
 			.d2l-navigation-immersive-margin {
+				display: flex;
+				justify-content: center;
 				margin: 0 30px;
 			}
 
@@ -41,9 +43,10 @@ Polymer-based web component for the immersive navigation component
 				display: flex;
 				height: var(--d2l-navigation-immersive-height-main);
 				justify-content: space-between;
-				margin: 0 auto;
+				margin: 0 -7px;
 				max-width: var(--d2l-navigation-immersive-content-max-width, 100%);
 				overflow: hidden;
+				width: 100%;
 			}
 
 			.d2l-navigation-immersive-left ::slotted(*),
@@ -117,7 +120,6 @@ Polymer-based web component for the immersive navigation component
 				right: 0;
 				top: calc(var(--d2l-navigation-immersive-height-main) + 5px);
 			}
-
 			@media (max-width: 929px) {
 				.d2l-navigation-immersive-margin {
 					margin: 0 24px;
@@ -162,6 +164,7 @@ Polymer-based web component for the immersive navigation component
 				}
 				d2l-navigation-link-back {
 					--d2l-navigation-link-back-left-padding: 6px;
+					margin: 0
 				}
 			}
 

--- a/d2l-navigation-immersive.html
+++ b/d2l-navigation-immersive.html
@@ -38,10 +38,11 @@ Polymer-based web component for the immersive navigation component
 			}
 
 			.d2l-navigation-immersive-container {
+				margin: 0 auto;
+				max-width: var(--d2l-navigation-immersive-content-max-width, 100%);
 				display: flex;
 				height: var(--d2l-navigation-immersive-height-main);
 				justify-content: space-between;
-				margin: 0 -7px;
 				overflow: hidden;
 			}
 

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots-max-width.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots-max-width.html
@@ -14,7 +14,7 @@
 		<link rel="import" href="../../d2l-navigation-immersive.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles">
-				:root {
+				html {
 					--d2l-navigation-immersive-content-max-width: 900px;
 				}
 				body {

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots-max-width.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots-max-width.html
@@ -14,6 +14,9 @@
 		<link rel="import" href="../../d2l-navigation-immersive.html">
 		<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles">
+				:root {
+					--d2l-navigation-immersive-content-max-width: 900px;
+				}
 				body {
 					background-color: pink;
 					padding: 0;
@@ -32,7 +35,6 @@
 		<style>
 			html {
 				font-size: 20px;
-				--d2l-navigation-immersive-content-max-width: 900px;
 			}
 			body {
 				overflow-x: hidden;

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots-max-width.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots-max-width.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-navigation-immersive demo</title>
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<link rel="import" href="../../../iron-demo-helpers/demo-pages-shared-styles.html">
+		<link rel="import" href="../../../iron-demo-helpers/demo-snippet.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography.html">
+		<link rel="import" href="../../../d2l-typography/d2l-typography-shared-styles.html">
+		<link rel="import" href="../../d2l-navigation-button.html">
+		<link rel="import" href="../../d2l-navigation-button-close.html">
+		<link rel="import" href="../../d2l-navigation-immersive.html">
+		<custom-style>
+			<style is="custom-style" include="demo-pages-shared-styles">
+				body {
+					background-color: pink;
+					padding: 0;
+				}
+				demo-snippet {
+					--demo-snippet-demo: {
+						background-color: transparent;
+						padding: 0;
+					}
+				}
+			</style>
+		</custom-style>
+		<custom-style include="d2l-typography">
+			<style is="custom-style" include="d2l-typography"></style>
+		</custom-style>
+		<style>
+			html {
+				font-size: 20px;
+				--d2l-navigation-immersive-content-max-width: 900px;
+			}
+			body {
+				overflow-x: hidden;
+			}
+			.page-contents {
+				margin: 0 20px;
+			}
+			div[slot="middle"]#middle {
+				display: table-cell;
+				vertical-align: middle;
+			}
+		</style>
+	</head>
+	<body unresolved class="d2l-typography">
+		<div class="vertical-section-container centered" style="max-width: 900px;">
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+						<div id="middle" class="d2l-typography d2l-body-standard" slot="middle">
+							Economics 101
+						</div>
+						<div slot="right">
+							<d2l-navigation-button text="A button">One Button</d2l-navigation-button>
+							<d2l-navigation-button-close></d2l-navigation-button-close>
+							<d2l-navigation-button text="Another button">Two Button</d2l-navigation-button>
+						</div>
+					</d2l-navigation-immersive>
+					<div class="page-contents">
+						<p>First Item in Page Content</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+						<p>Page Contents</p>
+					</div>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/demo/navigation-immersive.html
+++ b/demo/navigation-immersive.html
@@ -44,6 +44,9 @@
 
 			<h3>d2l-navigation-immersive (no middle slot, no right slot)</h3>
 			<iframe src="./navigation-immersive-demos/navigation-immersive-no-slots.html"></iframe>
+
+			<h3> d2l-navigation-immersive optional max width (900px)</h3>
+			<iframe src="./navigation-immersive-demos/navigation-immersive-all-slots-max-width.html"></iframe>
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
While integrating the immersive nav into Brightspace for Parents, and Portfolio I noticed that the immersive nav wasn't aligning the back button with our page content.  I confirmed with @geurts that it should be aligned with the content.

In this pr I'm adding a css variable to allow the consumer to set the content max width.  Additionally it looks like my vscode normalized the line endings to LF in the files i've touched.

Demo image:
![image](https://user-images.githubusercontent.com/1779270/52641493-9ae63780-2e9e-11e9-9d04-21cbc4e73d68.png)
