### PR TITLE
Use a web component compatible polyfill for ResizeObserver

### DIFF
--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -13,7 +13,7 @@ import '@polymer/polymer/polymer-legacy.js';
 
 import 'd2l-colors/d2l-colors.js';
 import 'fastdom/fastdom.js';
-import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
+import { ResizeObserver } from 'd2l-resize-aware/resize-observer-module.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import './d2l-navigation.js';
 import './d2l-navigation-link-back.js';

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "resize-observer-polyfill": "^1.5.0",
+    "d2l-resize-aware": "git://github.com/BrightspaceUI/resize-aware.git#semver:^1",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
     "@polymer/polymer": "^3.0.0"
   }


### PR DESCRIPTION
The ResizeObserver polyfill being used here has [an issue](https://github.com/que-etc/resize-observer-polyfill/issues/51) in that it fails to respond to resizes caused by changes in the shadow DOM of webcomponents.

This PR switches to using a polyfill that correctly handles web components.