### PR TITLE
Slot in navigation band

### DIFF
--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -1,6 +1,8 @@
 import 'd2l-colors/d2l-colors.js';
+import './d2l-navigation-shared-styles';
 
 import {PolymerElement, html} from '@polymer/polymer/polymer-element.js';
+import { navigationSharedStyle } from './d2l-navigation-shared-styles';
 /**
 `d2l-navigation-band`
 Polymer-based web component for a solid colour band that runs along the top of the navigational header
@@ -11,16 +13,19 @@ class D2LNavigationBand extends PolymerElement {
 
 	static get template() {
 		const template = html`
-
+		${navigationSharedStyle}
 		<style>
 			:host {
-				border-top-color: var(--d2l-branding-primary-color, var(--d2l-color-celestine));
-				border-top-style: solid;
-				border-top-width: 4px;
+				background: var(--d2l-branding-primary-color, var(--d2l-color-celestine));
+				min-height: 4px;
 				display: block;
 			}
 		</style>
-
+		<div class="d2l-navigation-centerer">
+			<div class="d2l-navigation-gutters">
+				<slot></slot>
+			</div>
+		</div>
 		`;
 		template.setAttribute('strip-whitespace', '');
 		return template;

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -16,9 +16,9 @@ class D2LNavigationBand extends PolymerElement {
 		${navigationSharedStyle}
 		<style>
 			:host {
-				background: var(--d2l-branding-primary-color, var(--d2l-color-celestine));
-				min-height: 4px;
+				background-color: var(--d2l-branding-primary-color, var(--d2l-color-celestine));
 				display: block;
+				min-height: 4px;
 			}
 		</style>
 		<div class="d2l-navigation-centerer">

--- a/d2l-navigation.js
+++ b/d2l-navigation.js
@@ -30,7 +30,7 @@ class D2LNavigation extends PolymerElement {
 				width: 100%;
 			}
 		</style>
-		<d2l-navigation-band></d2l-navigation-band>
+		<d2l-navigation-band><slot name="navigation-band"></slot></d2l-navigation-band>
 		<slot></slot>
 		<div class="d2l-navigation-shadow-drop-border"></div>
 		`;

--- a/demo/navigation-band.html
+++ b/demo/navigation-band.html
@@ -58,7 +58,16 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 					<d2l-navigation-band></d2l-navigation-band>
 				</template>
 			</demo-snippet>
-		</div>`;
+		</div>
+		<h3>d2l-navigation-band slotted content</h3>
+		<div class="vertical-section-container">
+			<demo-snippet>
+					<template strip-whitespace="">
+						<d2l-navigation-band><button>test content</button><button>navigation band height increased</button></d2l-navigation-band>
+					</template>
+			</demo-snippet>
+		</div>
+		`;
 
 document.body.appendChild($_documentContainer.content);
 </script>

--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -93,6 +93,19 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 					</d2l-navigation>
 				</template>
 			</demo-snippet>
+			<h3>d2l-navigation - navigation band content slotted</h3>
+			<demo-snippet>
+				<template strip-whitespace="">
+					<d2l-navigation>
+						<div slot="navigation-band"><button>consortium 1</button><button>consortium 2</button></div>
+						<d2l-navigation-main-header>
+							<div slot="left" class="d2l-navigation-header-left">This should be on the left.  As the width changes it shrinks as needed.</div>
+
+							<div slot="right" class="d2l-navigation-header-right">This should be on the right.  It doesn't shrink.</div>
+						</d2l-navigation-main-header>
+					</d2l-navigation>
+				</template>
+			</demo-snippet>
 		</div>`;
 
 document.body.appendChild($_documentContainer.content);


### PR DESCRIPTION
Adding a slot to the navigation band so that we can render the consortium tabs

This allows for this:
![navigation-band](https://user-images.githubusercontent.com/1779270/60837926-1b2f7100-a18f-11e9-8078-a9c1bec9c322.png)
![navigation](https://user-images.githubusercontent.com/1779270/60837927-1b2f7100-a18f-11e9-8d5e-ddccbb7650ca.PNG)
