### PR TITLE
Add a CSS variable to allow the d2l-navigation shadow to be hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Then add the `d2l-navigation`, and provide sub elements `d2l-navigation-main-hea
 </d2l-navigation>
 ```
 
+***Relevant CSS class name:***
+* `--d2l-navigation-shadow-drop-border-display`: The default value is `block`, but this property can be used to hide the shadow by setting it to `none`.
+
 ### d2l-navigation-immersive
 
 Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyfill (for browsers who don't natively support web components), then import the following:

--- a/d2l-navigation.js
+++ b/d2l-navigation.js
@@ -22,6 +22,7 @@ class D2LNavigation extends PolymerElement {
 				position: relative;
 			}
 			.d2l-navigation-shadow-drop-border {
+				display: var(--d2l-navigation-shadow-drop-border-display, block);
 				background-color: rgba(0,0,0,0.02);
 				bottom: -4px;
 				height: 4px;


### PR DESCRIPTION
# Changes

This pull request adds the `--d2l-navigation-shadow-drop-border-display` CSS variable to allow the shadow to be hidden on specific pages.