### PR TITLE
Jroach/us108637

### DIFF
--- a/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
+++ b/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
@@ -55,10 +55,14 @@ class D2LNavigationLinkIterator extends PolymerElement {
 
 	_onNavigationIteratorButtonClicked(evt) {
 		if (evt.detail.type === 'previous') {
-			window.location.href = this.previousHref;
+			this._setWindowLocationHref(this.previousHref);
 		} else {
-			window.location.href = this.nextHref;
+			this._setWindowLocationHref(this.nextHref);
 		}
+	}
+
+	_setWindowLocationHref(href) {
+		window.location.href = href;
 	}
 }
 

--- a/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
+++ b/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
@@ -52,6 +52,7 @@ class D2LNavigationLinkIterator extends PolymerElement {
 				no-next=[[noNext]]
 				on-d2l-navigation-iterator-button-clicked="_onNavigationIteratorButtonClicked"
 			>
+			<slot></slot>
 			</d2l-navigation-iterator>
 		`;
 	}

--- a/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
+++ b/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
@@ -55,9 +55,9 @@ class D2LNavigationLinkIterator extends PolymerElement {
 
 	_onNavigationIteratorButtonClicked(evt) {
 		if (evt.detail.type === 'previous') {
-			window.location.replace(this.previousHref);
+			window.location.href = this.previousHref;
 		} else {
-			window.location.replace(this.nextHref);
+			window.location.href = this.nextHref;
 		}
 	}
 }

--- a/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
+++ b/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
@@ -1,5 +1,4 @@
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import 'd2l-typography/d2l-typography-shared-styles.js';
 import './d2l-navigation-iterator.js';
 
 /**
@@ -66,4 +65,4 @@ class D2LNavigationLinkIterator extends PolymerElement {
 	}
 }
 
-window.customElements.define('d2l-navigation-link-iterator', D2LNavigationLinkIterator);
+window.customElements.define(D2LNavigationLinkIterator.is, D2LNavigationLinkIterator);

--- a/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
+++ b/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
@@ -1,0 +1,68 @@
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import 'd2l-typography/d2l-typography-shared-styles.js';
+import './d2l-navigation-iterator.js';
+
+/**
+ * @customElement
+ * @polymer
+ */
+class D2LNavigationLinkIterator extends PolymerElement {
+	static get is() { return 'd2l-navigation-link-iterator'; }
+
+	static get properties() {
+		return {
+			previousHref: {
+				type: String
+			},
+			nextHref: {
+				type: String
+			},
+			previousText: {
+				type: String
+			},
+			nextText: {
+				type: String
+			},
+			hideText: {
+				type: Boolean,
+				value: false
+			},
+			noPrevious: {
+				type: Boolean,
+				value: false
+			},
+			noNext: {
+				type: Boolean,
+				value: false
+			}
+		};
+	}
+
+	static get template() {
+		return html`
+			<style>
+				:host {
+				}
+			</style>
+			<d2l-navigation-iterator
+				previous-text=[[previousText]]
+				next-text=[[nextText]]
+				hide-text=[[hideText]]
+				no-previous=[[noPrevious]]
+				no-next=[[noNext]]
+				on-d2l-navigation-iterator-button-clicked="_onNavigationIteratorButtonClicked"
+			>
+			</d2l-navigation-iterator>
+		`;
+	}
+
+	_onNavigationIteratorButtonClicked(evt) {
+		if (evt.detail.type === 'previous') {
+			window.location.replace(this.previousHref);
+		} else {
+			window.location.replace(this.nextHref);
+		}
+	}
+}
+
+window.customElements.define('d2l-navigation-link-iterator', D2LNavigationLinkIterator);

--- a/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
+++ b/components/d2l-navigation-iterator/d2l-navigation-link-iterator.js
@@ -40,10 +40,6 @@ class D2LNavigationLinkIterator extends PolymerElement {
 
 	static get template() {
 		return html`
-			<style>
-				:host {
-				}
-			</style>
 			<d2l-navigation-iterator
 				previous-text=[[previousText]]
 				next-text=[[nextText]]

--- a/demo/d2l-navigation-link-iterator.html
+++ b/demo/d2l-navigation-link-iterator.html
@@ -38,12 +38,62 @@
 	</head>
 	<body class="d2l-typography">
 		<div class="vertical-section-container fixedSize">
-			<h3>d2l-navigation-item-iterator only provide hrefs demo</h3>
+			<h3>d2l-navigation-item-iterator w/ hrefs only demo</h3>
 			<demo-snippet>
 				<template strip-whitespace>
 					<d2l-navigation-link-iterator previous-href="https://www.d2l.com" next-href="https://www.nfl.com"></d2l-navigation-link-iterator>
 				</template>
-			</demo-snippet>
+            </demo-snippet>
+            <h3>d2l-navigation-item-iterator w/ count (hide-text) demo</h3>
+            <demo-snippet>
+				<template strip-whitespace>
+                    <d2l-navigation-link-iterator previous-href="https://www.d2l.com" next-href="https://www.nfl.com" hide-text>
+                        <span>User 1 of 17</span>
+                    </d2l-navigation-link-iterator>
+				</template>
+            </demo-snippet>
+            <h3>d2l-navigation-item-iterator w/ separator (hide-text) demo</h3>
+            <demo-snippet>
+				<template strip-whitespace>
+                    <d2l-navigation-link-iterator previous-href="https://www.d2l.com" next-href="https://www.nfl.com" hide-text>
+                        <d2l-navigation-separator></d2l-navigation-separator>
+                    </d2l-navigation-link-iterator>
+				</template>
+            </demo-snippet>
+            <h3>d2l-navigation-item-iterator w/ custom labels demo</h3>
+            <demo-snippet>
+				<template strip-whitespace>
+                    <d2l-navigation-link-iterator 
+                        previous-href="https://www.d2l.com"
+                        next-href="https://www.nfl.com"
+                        previous-text="D2L"
+                        next-text="NFL"
+                    >
+                    </d2l-navigation-link-iterator>
+				</template>
+            </demo-snippet>
+            <h3>d2l-navigation-item-iterator (no-previous) demo</h3>
+			<demo-snippet>
+				<template strip-whitespace>
+                    <d2l-navigation-link-iterator 
+                        no-previous
+                        next-href="https://www.nfl.com"
+                        next-text="NFL"
+                    >
+                    </d2l-navigation-link-iterator>
+				</template>
+            </demo-snippet>
+            <h3>d2l-navigation-item-iterator (no-next) demo</h3>
+			<demo-snippet>
+				<template strip-whitespace>
+                    <d2l-navigation-link-iterator 
+                        previous-href="https://www.d2l.com"
+                        previous-text="D2L"
+                        no-next
+                    >
+                    </d2l-navigation-link-iterator>
+				</template>
+            </demo-snippet>
 		</div>
 	</body>
 </html>

--- a/demo/d2l-navigation-link-iterator.html
+++ b/demo/d2l-navigation-link-iterator.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+
+		<title>d2l-navigation-link-iterator demo</title>
+		<script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+
+		<!-- For IE11 -->
+		<script src="../node_modules/lie/dist/lie.polyfill.min.js"></script>
+		<script type="module" src="../node_modules/whatwg-fetch/fetch.js"></script>
+		<script type="module" src="../node_modules/url-polyfill/url-polyfill.js"></script>
+
+		<script type="module">
+			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';
+			import '@polymer/iron-demo-helpers/demo-snippet';
+			import 'd2l-typography/d2l-typography.js';
+			import '../d2l-navigation-separator.js';
+			import '../components/d2l-navigation-iterator/d2l-navigation-link-iterator.js';
+
+			const $_documentContainer = document.createElement('template');
+			$_documentContainer.innerHTML = `
+				<custom-style>
+					<style is="custom-style" include="demo-pages-shared-styles"></style>
+				</custom-style>
+				<custom-style include="d2l-typography">
+					<style is="custom-style" include="d2l-typography"></style>
+				</custom-style>
+				<style>
+					html {
+						font-size: 20px;
+					}
+				</style>
+			`;
+			document.body.appendChild($_documentContainer.content);
+		</script>
+	</head>
+	<body class="d2l-typography">
+		<div class="vertical-section-container fixedSize">
+			<h3>d2l-navigation-item-iterator only provide hrefs demo</h3>
+			<demo-snippet>
+				<template strip-whitespace>
+					<d2l-navigation-link-iterator previous-href="https://www.d2l.com" next-href="https://www.nfl.com"></d2l-navigation-link-iterator>
+				</template>
+			</demo-snippet>
+		</div>
+	</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "polymer-cli": "^1.9.6",
     "require-dir": "^1.2.0",
     "sauce-connect-launcher": "^1.2.4",
+    "sinon": "^7.3.2",
     "url-polyfill": "^1.1.3",
     "wct-browser-legacy": "^1.0.1",
     "whatwg-fetch": "^3.0.0"

--- a/test/d2l-navigation-link-iterator.html
+++ b/test/d2l-navigation-link-iterator.html
@@ -26,6 +26,8 @@
 
 		<script type="module">
 			import '../components/d2l-navigation-iterator/d2l-navigation-link-iterator.js';
+			import sinon from '../node_modules/sinon/pkg/sinon-esm.js';
+
 			let linkIterator, iterator;
 
 			suite('d2l-navigation-iterator', function() {
@@ -59,6 +61,32 @@
 					assert.equal(linkIterator.noNext, iterator.noNext);
 					linkIterator.noNext = !linkIterator.noNext;
 					assert.equal(linkIterator.noNext, iterator.noNext);
+				});
+				test('_onNavigationIteratorButtonClicked follows correct path when previous button clicked', function() {
+					const mockLinkIterator = sinon.mock(linkIterator);
+					mockLinkIterator.expects('_setWindowLocationHref').once().withArgs('https://www.previous.com');
+
+					const evt = {
+						detail: {
+							type: 'previous'
+						}
+					};
+					linkIterator._onNavigationIteratorButtonClicked(evt);
+
+					mockLinkIterator.verify();
+				});
+				test('_onNavigationIteratorButtonClicked follows correct path when next button clicked', function() {
+					const mockLinkIterator = sinon.mock(linkIterator);
+					mockLinkIterator.expects('_setWindowLocationHref').once().withArgs('https://www.next.com');
+
+					const evt = {
+						detail: {
+							type: 'next'
+						}
+					};
+					linkIterator._onNavigationIteratorButtonClicked(evt);
+
+					mockLinkIterator.verify();
 				});
 			});
 		</script>

--- a/test/d2l-navigation-link-iterator.html
+++ b/test/d2l-navigation-link-iterator.html
@@ -6,6 +6,7 @@
 		<title>d2l-navigation-link-iterator test</title>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
+		<script src="../node_modules/sinon/pkg/sinon.js"></script>
 		<script type="module" src="../components/d2l-navigation-iterator/d2l-navigation-link-iterator.js"></script>
 	</head>
 	<body>
@@ -26,8 +27,6 @@
 
 		<script type="module">
 			import '../components/d2l-navigation-iterator/d2l-navigation-link-iterator.js';
-			import sinon from '../node_modules/sinon/pkg/sinon-esm.js';
-
 			let linkIterator, iterator;
 
 			suite('d2l-navigation-iterator', function() {

--- a/test/d2l-navigation-link-iterator.html
+++ b/test/d2l-navigation-link-iterator.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-navigation-link-iterator test</title>
+		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="../../wct-browser-legacy/browser.js"></script>
+		<script type="module" src="../components/d2l-navigation-iterator/d2l-navigation-link-iterator.js"></script>
+	</head>
+	<body>
+		<test-fixture id="default">
+			<template strip-whitespace>
+				<d2l-navigation-link-iterator
+					previous-href="https://www.previous.com"
+					previous-text="prev"
+					next-href="https://www.next.com"
+					next-text="next"
+					hide-text
+					no-previous
+					no-next
+				>
+				</d2l-navigation-link-iterator>
+			</template>
+		</test-fixture>
+
+		<script type="module">
+			import '../components/d2l-navigation-iterator/d2l-navigation-link-iterator.js';
+			let linkIterator, iterator;
+
+			suite('d2l-navigation-iterator', function() {
+				setup(function() {
+					linkIterator = fixture('default');
+					iterator = linkIterator.shadowRoot.querySelector('d2l-navigation-iterator');
+				});
+				test('instantiating the element works', function() {
+					assert.equal(linkIterator.tagName.toLowerCase(), 'd2l-navigation-link-iterator');
+				});
+				test('link iterator contains a child iterator item', function() {
+					assert.isNotNull(iterator);
+				});
+				test('attributes are passed down to child iterator', function() {
+					assert.equal(linkIterator.previousText, iterator.previousText);
+					linkIterator.previousText = 'newP';
+					assert.equal(linkIterator.previousText, iterator.previousText);
+
+					assert.equal(linkIterator.nextText, iterator.nextText);
+					linkIterator.nextText = 'newN';
+					assert.equal(linkIterator.nextText, iterator.nextText);
+
+					assert.equal(linkIterator.hideText, iterator.hideText);
+					linkIterator.hideText = !linkIterator.hideText;
+					assert.equal(linkIterator.hideText, iterator.hideText);
+
+					assert.equal(linkIterator.noPrevious, iterator.noPrevious);
+					linkIterator.noPrevious = !linkIterator.noPrevious;
+					assert.equal(linkIterator.noPrevious, iterator.noPrevious);
+
+					assert.equal(linkIterator.noNext, iterator.noNext);
+					linkIterator.noNext = !linkIterator.noNext;
+					assert.equal(linkIterator.noNext, iterator.noNext);
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,7 @@
 				'd2l-navigation-button.html',
 				'navigation-main-footer.html',
 				'd2l-navigation-iterator.html',
+				'd2l-navigation-link-iterator.html',
 				'd2l-navigation-iterator-item.html'
 			];
 			for (var i = 0; i < tests.length; i++) {


### PR DESCRIPTION
[US108637](https://rally1.rallydev.com/#/detail/userstory/322122660856?fdp=true): [UI] New web component that wraps d2l-navigation-iterator and treats the buttons as links

Thoughts on the name? `d2l-navigation-link-iterator` was my initial idea.

Also, since this is simply a logic wrapper, I don't think we need a designer sign off. Please let me know if you think otherwise