### PR TITLE
Use min-width 0 so the middle slot knows its width

### DIFF
--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -90,6 +90,7 @@ class D2LNavigationImmsersive extends PolymerElement {
 				margin: 0 24px;
 				padding: 0 24px;
 				width: 100%;
+				min-width: 0;
 			}
 
 			.d2l-navigation-immersive-middle.d2l-navigation-immersive-middle-no-right-border {


### PR DESCRIPTION
This is the only change needed here, then I need to update the styles in LMS and we should get what is shown in the gif.

![fix_long](https://user-images.githubusercontent.com/1176292/63376554-177d3580-c35c-11e9-8057-5e3db0640452.gif)
