### PR TITLE
using new frau-ci release features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,8 @@ script:
     echo "Not a pull request and/or no secure environment variables, running headless tests...";
     npm run test:polymer:local || travis_terminate 1;
   fi
-- |
-  if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_EVENT_TYPE != "cron" ]; then
-    echo "Not a Pull Request and on branch master so bumping version";
-    frauci-update-version;
-    export TRAVIS_TAG=$(frauci-get-version)
-  fi
+after_success:
+- frauci-update-version -d=skip && export TRAVIS_TAG=$(frauci-get-version)
 deploy:
   provider: releases
   api_key: "$GITHUB_RELEASE_TOKEN"

--- a/README.md
+++ b/README.md
@@ -374,11 +374,8 @@ npm test
 [ci-url]: https://travis-ci.org/BrightspaceUI/navigation
 [ci-image]: https://travis-ci.org/BrightspaceUI/navigation.svg?branch=master
 
-## Versioning
+## Versioning & Releasing
 
-Commits and PR merges to master will automatically do a minor version bump which will:
-* Update the version in `package.json`
-* Add a tag matching the new version
-* Create a github release matching the new version
+All version changes should obey [semantic versioning](https://semver.org/) rules.
 
-By using either **[increment major]** or **[increment patch]** notation inside your merge message, you can overwrite the default version upgrade of minor to the position of your choice.
+Include either `[increment major]`, `[increment minor]` or `[increment patch]` in your merge commit message to automatically increment the `package.json` version and create a tag during the next build.


### PR DESCRIPTION
I'm applying this everywhere -- this means you'll need to explicitly include `[increment whatever]` if you want the version to bump. This is more in line with how we want to be thoughtful about our semver changes in library repos like BrightspaceUI vs. FRAs which care a lot less.