### PR TITLE
US109311 - Add Custom Scrollbars to Navigation Band for Org Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,11 @@ Then add the `d2l-navigation-band`.
 <d2l-navigation-band></d2l-navigation-band>
 ```
 
+The `d2l-navigation-band` also includes a `slot` with a custom scrollbar and fading effects, but this has only been designed for the `d2l-organization-consortium-tabs` and should not be used for anything else right now.
+
 ***Relevant CSS class name:***
 * `--d2l-branding-primary-color`: Used to customize the colour of the top navigation band.
+* `--d2l-navigation-band-slot-height`: When using the slot, this is needed to setup the proper scrollbar and fading effects.
 
 ---
 

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -11,6 +11,15 @@ Polymer-based web component for a solid colour band that runs along the top of t
 */
 class D2LNavigationBand extends PolymerElement {
 
+	static get properties() {
+		return {
+			customScroll: {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
+			}
+		};
+	}
 	static get template() {
 		const template = html`
 		${navigationSharedStyle}
@@ -19,6 +28,40 @@ class D2LNavigationBand extends PolymerElement {
 				background-color: var(--d2l-branding-primary-color, var(--d2l-color-celestine));
 				display: block;
 				min-height: 4px;
+
+				overflow-x: auto;
+				overflow-y: hidden;
+			}
+
+			:host([custom-scroll]) {
+				 /* Firefox Styles */
+				 scrollbar-color: var(--d2l-color-galena) var(--d2l-color-sylvite);
+				 scrollbar-width: thin;
+
+				 /* IE Styles */
+				 scrollbar-face-color:var(--d2l-color-galena);
+				 scrollbar-arrow-color: var(--d2l-color-sylvite);
+				 scrollbar-track-color: var(--d2l-color-sylvite);
+				 scrollbar-shadow-color: var(--d2l-color-sylvite);
+			 }
+			/* Webkit Styles */
+			:host([custom-scroll])::-webkit-scrollbar {
+				background-color: var(--d2l-color-sylvite);
+				height: 9px;
+			}
+			:host([custom-scroll])::-webkit-scrollbar-thumb {
+				background-color: var(--d2l-color-galena);
+				border-radius: 8px;
+				border-bottom: 1px solid var(--d2l-color-sylvite);
+				border-top: 1px solid var(--d2l-color-sylvite);
+			}
+			/* Styles to ensure the right padding is respected when scrolling */
+			.d2l-navigation-centerer {
+				line-height: 0;
+			}
+			.d2l-navigation-gutters {
+				display: inline-block;
+				line-height: 0;
 			}
 		</style>
 		<div class="d2l-navigation-centerer">
@@ -29,6 +72,13 @@ class D2LNavigationBand extends PolymerElement {
 		`;
 		template.setAttribute('strip-whitespace', '');
 		return template;
+	}
+	ready() {
+		super.ready();
+		const userAgent = navigator.userAgent.toLowerCase();
+		if (userAgent.indexOf('win') > -1 && userAgent.indexOf('mobile') === -1) {
+			this.customScroll = true;
+		}
 	}
 }
 customElements.define('d2l-navigation-band', D2LNavigationBand);

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -15,8 +15,11 @@ class D2LNavigationBand extends PolymerElement {
 		return {
 			customScroll: {
 				type: Boolean,
-				value: false,
-				reflectToAttribute: true
+				readOnly: true,
+				value: function() {
+					const userAgent = navigator.userAgent.toLowerCase();
+					return (userAgent.indexOf('win') > -1 && userAgent.indexOf('mobile') === -1);
+				}
 			}
 		};
 	}
@@ -25,60 +28,77 @@ class D2LNavigationBand extends PolymerElement {
 		${navigationSharedStyle}
 		<style>
 			:host {
-				background-color: var(--d2l-branding-primary-color, var(--d2l-color-celestine));
+				background: linear-gradient(180deg, var(--d2l-branding-primary-color, var(--d2l-color-celestine)) var(--d2l-navigation-band-slot-height, 1.5rem), #ffffff 0%);
 				display: block;
 				min-height: 4px;
+			}
 
+			.d2l-navigation-scroll {
 				overflow-x: auto;
 				overflow-y: hidden;
 			}
 
-			:host([custom-scroll]) {
-				 /* Firefox Styles */
-				 scrollbar-color: var(--d2l-color-galena) var(--d2l-color-sylvite);
-				 scrollbar-width: thin;
+			.d2l-navigation-scroll[custom-scroll] {
+				/* Firefox Styles */
+				scrollbar-color: var(--d2l-color-galena) var(--d2l-color-sylvite);
+				scrollbar-width: thin;
 
-				 /* IE Styles */
-				 scrollbar-face-color:var(--d2l-color-galena);
-				 scrollbar-arrow-color: var(--d2l-color-sylvite);
-				 scrollbar-track-color: var(--d2l-color-sylvite);
-				 scrollbar-shadow-color: var(--d2l-color-sylvite);
-			 }
+				/* IE Styles */
+				scrollbar-face-color: var(--d2l-color-galena);
+				scrollbar-arrow-color: var(--d2l-color-sylvite);
+				scrollbar-track-color: var(--d2l-color-sylvite);
+				scrollbar-shadow-color: var(--d2l-color-sylvite);
+			}
 			/* Webkit Styles */
-			:host([custom-scroll])::-webkit-scrollbar {
+			.d2l-navigation-scroll[custom-scroll]::-webkit-scrollbar {
+				border-radius: 8px;
 				background-color: var(--d2l-color-sylvite);
 				height: 9px;
 			}
-			:host([custom-scroll])::-webkit-scrollbar-thumb {
+			.d2l-navigation-scroll[custom-scroll]::-webkit-scrollbar-thumb {
 				background-color: var(--d2l-color-galena);
 				border-radius: 8px;
 				border-bottom: 1px solid var(--d2l-color-sylvite);
 				border-top: 1px solid var(--d2l-color-sylvite);
 			}
+			/* Faded edges styles */
+			.d2l-navigation-scroll[custom-scroll]:before,
+			.d2l-navigation-scroll[custom-scroll]:after {
+				content: '';
+				position: absolute;
+				height: 100%;
+				max-height: var(--d2l-navigation-band-slot-height, 1.5rem);
+				top: 0;
+				z-index: 2;
+			}
+			.d2l-navigation-scroll[custom-scroll]:before {
+				left: 0;
+				background: linear-gradient(to right, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
+			}
+			.d2l-navigation-scroll[custom-scroll]:after {
+				right: 0;
+				background: linear-gradient(to left, var(--d2l-branding-primary-color, var(--d2l-color-celestine)), transparent);
+			}
 			/* Styles to ensure the right padding is respected when scrolling */
 			.d2l-navigation-centerer {
 				line-height: 0;
+				position: relative;
 			}
 			.d2l-navigation-gutters {
 				display: inline-block;
-				line-height: 0;
+				vertical-align: top;
 			}
 		</style>
 		<div class="d2l-navigation-centerer">
-			<div class="d2l-navigation-gutters">
-				<slot></slot>
+			<div class="d2l-navigation-scroll" custom-scroll$=[[customScroll]]>
+				<div class="d2l-navigation-gutters">
+					<slot></slot>
+				</div>
 			</div>
 		</div>
 		`;
 		template.setAttribute('strip-whitespace', '');
 		return template;
-	}
-	ready() {
-		super.ready();
-		const userAgent = navigator.userAgent.toLowerCase();
-		if (userAgent.indexOf('win') > -1 && userAgent.indexOf('mobile') === -1) {
-			this.customScroll = true;
-		}
 	}
 }
 customElements.define('d2l-navigation-band', D2LNavigationBand);

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -86,6 +86,7 @@ class D2LNavigationBand extends PolymerElement {
 			}
 			.d2l-navigation-gutters {
 				display: inline-block;
+				position: unset;
 				vertical-align: top;
 			}
 		</style>

--- a/d2l-navigation-shared-styles.js
+++ b/d2l-navigation-shared-styles.js
@@ -16,10 +16,20 @@ export const navigationSharedStyle = html`
 				position: relative;
 			}
 
+			.d2l-navigation-scroll[custom-scroll]:before,
+			.d2l-navigation-scroll[custom-scroll]:after {
+				width: 2.439%;
+			}
+
 			@media (max-width: 615px) {
 				.d2l-navigation-gutters {
 					padding-left: 15px;
 					padding-right: 15px;
+				}
+
+				.d2l-navigation-scroll[custom-scroll]:before,
+				.d2l-navigation-scroll[custom-scroll]:after {
+					width: 15px;
 				}
 			}
 
@@ -27,6 +37,11 @@ export const navigationSharedStyle = html`
 				.d2l-navigation-gutters {
 					padding-left: 30px;
 					padding-right: 30px;
+				}
+
+				.d2l-navigation-scroll[custom-scroll]:before,
+				.d2l-navigation-scroll[custom-scroll]:after {
+					width: 30px;
 				}
 			}
 		</style>

--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -56,6 +56,13 @@ $_documentContainer.innerHTML = `<style>
 			.d2l-navigation-header-right {
 				background-color: lightblue;
 			}
+			div[slot="navigation-band"] {
+				line-height: 1.4rem;
+				white-space: nowrap;
+			}
+			button {
+				width: 200px;
+			}
 		</style>`;
 
 document.body.appendChild($_documentContainer.content);
@@ -97,7 +104,7 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template strip-whitespace="">
 					<d2l-navigation>
-						<div slot="navigation-band"><button>consortium 1</button><button>consortium 2</button></div>
+						<div slot="navigation-band"><button>consortium 1</button><button>consortium 2</button><button>consortium 3</button><button>consortium 4</button></div>
 						<d2l-navigation-main-header>
 							<div slot="left" class="d2l-navigation-header-left">This should be on the left.  As the width changes it shrinks as needed.</div>
 

--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -42,6 +42,7 @@ const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<style>
 			html {
+				--d2l-navigation-band-slot-height: 26px;
 				font-size: 18px;
 			}
 			d2l-navigation-main-header {
@@ -57,10 +58,10 @@ $_documentContainer.innerHTML = `<style>
 				background-color: lightblue;
 			}
 			div[slot="navigation-band"] {
-				line-height: 1.4rem;
 				white-space: nowrap;
 			}
 			button {
+				height: 26px;
 				width: 200px;
 			}
 		</style>`;
@@ -72,7 +73,7 @@ document.body.appendChild($_documentContainer.content);
 		<script type="module">
 const $_documentContainer = document.createElement('template');
 
-$_documentContainer.innerHTML = `<div class="vertical-section-container centered" style="max-width: 1200px;">
+$_documentContainer.innerHTML = `<div class="vertical-section-container centered" style="max-width: 1500px;">
 			<h3>d2l-navigation - Header and Footer</h3>
 			<demo-snippet>
 				<template strip-whitespace="">
@@ -104,7 +105,36 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 			<demo-snippet>
 				<template strip-whitespace="">
 					<d2l-navigation>
-						<div slot="navigation-band"><button>consortium 1</button><button>consortium 2</button><button>consortium 3</button><button>consortium 4</button></div>
+						<div slot="navigation-band">
+							<button>consortium 1</button>
+							<button>consortium 2</button>
+							<button>consortium 3</button>
+							<button>consortium 4</button>
+						</div>
+						<d2l-navigation-main-header>
+							<div slot="left" class="d2l-navigation-header-left">This should be on the left.  As the width changes it shrinks as needed.</div>
+
+							<div slot="right" class="d2l-navigation-header-right">This should be on the right.  It doesn't shrink.</div>
+						</d2l-navigation-main-header>
+					</d2l-navigation>
+				</template>
+			</demo-snippet>
+			<h3>d2l-navigation - navigation band content slotted - scrollbar</h3>
+			<demo-snippet>
+				<template strip-whitespace="">
+					<d2l-navigation>
+						<div slot="navigation-band">
+							<button>consortium 1</button>
+							<button>consortium 2</button>
+							<button>consortium 3</button>
+							<button>consortium 4</button>
+							<button>consortium 5</button>
+							<button>consortium 6</button>
+							<button>consortium 7</button>
+							<button>consortium 8</button>
+							<button>consortium 9</button>
+							<button>consortium 10</button>
+						</div>
 						<d2l-navigation-main-header>
 							<div slot="left" class="d2l-navigation-header-left">This should be on the left.  As the width changes it shrinks as needed.</div>
 

--- a/test/navigation-band.html
+++ b/test/navigation-band.html
@@ -63,7 +63,7 @@
 					teardown(function() {
 						Object.defineProperty(window.navigator, 'userAgent', {value: originalUserAgent, configurable: true});
 					});
-					test('custom scrollbars are ' + (result ? 'on ' : 'off ') + 'for user agent of "' + userAgent + '"', function() {
+					test(`custom scrollbars are ${result ? 'on' : 'off'} for user agent of "${userAgent}"`, function() {
 						Object.defineProperty(window.navigator, 'userAgent', {value: userAgent, configurable: true});
 						var element = fixture('basic');
 						assert.equal(element.customScroll, result);

--- a/test/navigation-band.html
+++ b/test/navigation-band.html
@@ -15,13 +15,61 @@
 			</template>
 		</test-fixture>
 		<script type="module">
-import '../d2l-navigation-band.js';
-suite('d2l-navigation-band', function() {
-	test('instantiating the element works', function() {
-		var element = fixture('basic');
-		assert.equal(element.tagName.toLowerCase(), 'd2l-navigation-band');
-	});
-});
-</script>
+			import '../d2l-navigation-band.js';
+			let originalUserAgent;
+
+			suite('d2l-navigation-band', function() {
+				test('instantiating the element works', function() {
+					var element = fixture('basic');
+					assert.equal(element.tagName.toLowerCase(), 'd2l-navigation-band');
+				});
+			});
+			suite('d2l-navigation-band custom css scrollbar', function() {
+				[{
+					userAgent: '',
+					result: false
+				},
+				{
+					userAgent: 'test',
+					result: false
+				},
+				{
+					userAgent: 'Mac OS X',
+					result: false
+				},
+				{
+					userAgent: 'Mac OS X Mobile',
+					result: false
+				},
+				{
+					userAgent: 'Windows',
+					result: true
+				},
+				{
+					userAgent: 'Windows Mobile',
+					result: false
+				},
+				{
+					userAgent: 'Mobile',
+					result: false
+				},
+				{
+					userAgent: 'Windows Mac OS X',
+					result: true
+				}].forEach(function({ userAgent, result }) {
+					setup(function() {
+						originalUserAgent = navigator.userAgent;
+					});
+					teardown(function() {
+						Object.defineProperty(window.navigator, 'userAgent', {value: originalUserAgent, configurable: true});
+					});
+					test('custom scrollbars are ' + (result ? 'on ' : 'off ') + 'for user agent of "' + userAgent + '"', function() {
+						Object.defineProperty(window.navigator, 'userAgent', {value: userAgent, configurable: true});
+						var element = fixture('basic');
+						assert.equal(element.customScroll, result);
+					});
+				});
+			});
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
- Add custom scrollbar styles to the content inside the slot of the navigation band
- Only do so if we detect we are on a non-mobile Windows machine (want to leave the nice mobile and mac scrollbars alone)