### PR TITLE
US109896 - Add the ability to use a thin (1px) border on the notification dot

### DIFF
--- a/d2l-navigation-notification-icon.js
+++ b/d2l-navigation-notification-icon.js
@@ -31,6 +31,9 @@ class NavigationNotificationIcon extends PolymerElement {
                     width: 10px;
                     border-radius: 50%;
                 }
+                :host([thin-border]) .d2l-navigation-notification-icon-indicator {
+                    border-width: 1px;
+                }
             </style>
             <div class="d2l-navigation-notification-icon-indicator"></div>
 		`;


### PR DESCRIPTION
This will be used for the org tabs, but Jeff still wants the default to be 2px and the navigation buttons to use 2px, so they have not been updated to include this attribute.

(This file had mixed line endings, so look at the ignore whitespace diff).