### PR TITLE
Fix scrollbar gradients in navigation band

### DIFF
--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -68,6 +68,7 @@ class D2LNavigationBand extends PolymerElement {
 				position: absolute;
 				height: 100%;
 				max-height: var(--d2l-navigation-band-slot-height, 1.5rem);
+				pointer-events: none;
 				top: 0;
 				z-index: 2;
 			}


### PR DESCRIPTION
Don't let the gradients block from pressing the tab underneath