### PR TITLE
US111258 - Allow nav-band to listen for a scroll event

### DIFF
--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -122,8 +122,8 @@ class D2LNavigationBand extends PolymerElement {
 
 		var scrollAmount = e.detail.pointToCenter - 0.5 * scroll.offsetWidth;
 
-		if (dir === 'rtl') {
-			// Chrome
+		if (dir && dir.toLowerCase() === 'rtl') {
+			// Chrome and Safari
 			//scrollAmount = scroll.scrollWidth + e.detail.pointToCenter - 1.5 * scroll.offsetWidth;
 
 			//Firefox
@@ -132,7 +132,7 @@ class D2LNavigationBand extends PolymerElement {
 			//Edge
 			//scrollAmount = 0.5 * scroll.offsetWidth - e.detail.pointToCenter;
 		}
-		requestAnimationFrame(function() {
+		requestAnimationFrame(() => {
 			scroll.scrollLeft = scrollAmount;
 		});
 	}

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -36,6 +36,7 @@ class D2LNavigationBand extends PolymerElement {
 			.d2l-navigation-scroll {
 				overflow-x: auto;
 				overflow-y: hidden;
+				scroll-behavior: smooth;
 			}
 
 			.d2l-navigation-scroll[custom-scroll] {
@@ -101,6 +102,24 @@ class D2LNavigationBand extends PolymerElement {
 		`;
 		template.setAttribute('strip-whitespace', '');
 		return template;
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		this.addEventListener('d2l-navigation-band-slot-scroll-request', this._handleScrollRequest);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		this.removeEventListener('d2l-navigation-band-slot-scroll-request', this._handleScrollRequest);
+	}
+
+	_handleScrollRequest(e) {
+		e.stopPropagation();
+		const scroll = this.shadowRoot.querySelector('.d2l-navigation-scroll');
+		requestAnimationFrame(function() {
+			scroll.scrollLeft = e.detail.pointToCenter - (scroll.offsetWidth / 2);
+		});
 	}
 }
 customElements.define('d2l-navigation-band', D2LNavigationBand);

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -31,6 +31,7 @@ class D2LNavigationBand extends PolymerElement {
 				background: linear-gradient(180deg, var(--d2l-branding-primary-color, var(--d2l-color-celestine)) var(--d2l-navigation-band-slot-height, 1.5rem), #ffffff 0%);
 				display: block;
 				min-height: 4px;
+				position: relative;
 			}
 
 			.d2l-navigation-scroll {
@@ -116,9 +117,23 @@ class D2LNavigationBand extends PolymerElement {
 
 	_handleScrollRequest(e) {
 		e.stopPropagation();
+		const dir = document.getElementsByTagName('html')[0].getAttribute('dir');
 		const scroll = this.shadowRoot.querySelector('.d2l-navigation-scroll');
+
+		var scrollAmount = e.detail.pointToCenter - 0.5 * scroll.offsetWidth;
+
+		if (dir === 'rtl') {
+			// Chrome
+			//scrollAmount = scroll.scrollWidth + e.detail.pointToCenter - 1.5 * scroll.offsetWidth;
+
+			//Firefox
+			//scrollAmount = e.detail.pointToCenter - 0.5 * scroll.offsetWidth;
+
+			//Edge
+			//scrollAmount = 0.5 * scroll.offsetWidth - e.detail.pointToCenter;
+		}
 		requestAnimationFrame(function() {
-			scroll.scrollLeft = e.detail.pointToCenter - (scroll.offsetWidth / 2);
+			scroll.scrollLeft = scrollAmount;
 		});
 	}
 }

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -31,6 +31,7 @@ class D2LNavigationBand extends PolymerElement {
 				background: linear-gradient(180deg, var(--d2l-branding-primary-color, var(--d2l-color-celestine)) var(--d2l-navigation-band-slot-height, 1.5rem), #ffffff 0%);
 				display: block;
 				min-height: 4px;
+				position: relative; /* Needed for Firefox */
 			}
 
 			.d2l-navigation-scroll {

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -117,23 +117,14 @@ class D2LNavigationBand extends PolymerElement {
 
 	_handleScrollRequest(e) {
 		e.stopPropagation();
-		const dir = document.getElementsByTagName('html')[0].getAttribute('dir');
-		const scroll = this.shadowRoot.querySelector('.d2l-navigation-scroll');
-
-		var scrollAmount = e.detail.pointToCenter - 0.5 * scroll.offsetWidth;
-
-		if (dir && dir.toLowerCase() === 'rtl') {
-			// Chrome and Safari
-			//scrollAmount = scroll.scrollWidth + e.detail.pointToCenter - 1.5 * scroll.offsetWidth;
-
-			//Firefox
-			//scrollAmount = e.detail.pointToCenter - 0.5 * scroll.offsetWidth;
-
-			//Edge
-			//scrollAmount = 0.5 * scroll.offsetWidth - e.detail.pointToCenter;
+		const dir = document.documentElement.getAttribute('dir') || 'ltr';
+		if (dir.toLowerCase() === 'rtl') {
+			return; // We turn off this feature in RTL due to browser inconsistencies
 		}
+
+		const scroll = this.shadowRoot.querySelector('.d2l-navigation-scroll');
 		requestAnimationFrame(() => {
-			scroll.scrollLeft = scrollAmount;
+			scroll.scrollLeft = e.detail.pointToCenter - 0.5 * scroll.offsetWidth;
 		});
 	}
 }

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -31,7 +31,6 @@ class D2LNavigationBand extends PolymerElement {
 				background: linear-gradient(180deg, var(--d2l-branding-primary-color, var(--d2l-color-celestine)) var(--d2l-navigation-band-slot-height, 1.5rem), #ffffff 0%);
 				display: block;
 				min-height: 4px;
-				position: relative;
 			}
 
 			.d2l-navigation-scroll {

--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -59,7 +59,6 @@ $_documentContainer.innerHTML = `<style>
 			}
 			div[slot="navigation-band"] {
 				white-space: nowrap;
-				position: relative; /* Needed for Firefox */
 			}
 			button {
 				height: 26px;

--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -124,16 +124,16 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 				<template strip-whitespace="">
 					<d2l-navigation>
 						<div slot="navigation-band">
-							<button>consortium 1</button>
-							<button>consortium 2</button>
-							<button>consortium 3</button>
-							<button>consortium 4</button>
-							<button>consortium 5</button>
-							<button>consortium 6</button>
-							<button>consortium 7</button>
-							<button>consortium 8</button>
-							<button>consortium 9</button>
-							<button>consortium 10</button>
+							<button class="scrollable">consortium 1</button>
+							<button class="scrollable">consortium 2</button>
+							<button class="scrollable">consortium 3</button>
+							<button class="scrollable">consortium 4</button>
+							<button class="scrollable">consortium 5</button>
+							<button class="scrollable">consortium 6</button>
+							<button class="scrollable">consortium 7</button>
+							<button class="scrollable">consortium 8</button>
+							<button class="scrollable">consortium 9</button>
+							<button class="scrollable">consortium 10</button>
 						</div>
 						<d2l-navigation-main-header>
 							<div slot="left" class="d2l-navigation-header-left">This should be on the left.  As the width changes it shrinks as needed.</div>
@@ -146,6 +146,27 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 		</div>`;
 
 document.body.appendChild($_documentContainer.content);
+</script>
+<script type="module">
+	requestAnimationFrame(function() {
+		const scrollTestButtons = document.querySelectorAll('.scrollable');
+		scrollTestButtons.forEach(function(button) {
+			button.addEventListener('click', function() {
+				button.dispatchEvent(
+					new CustomEvent(
+						'd2l-navigation-band-slot-scroll-request',
+						{
+							detail: {
+								pointToCenter: button.offsetLeft + (button.offsetWidth / 2)
+							},
+							bubbles: true,
+							composed: true
+						}
+					)
+				);
+			});
+		});
+	});
 </script>
 	</body>
 </html>

--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -148,10 +148,10 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 document.body.appendChild($_documentContainer.content);
 </script>
 <script type="module">
-	requestAnimationFrame(function() {
+	requestAnimationFrame(() => {
 		const scrollTestButtons = document.querySelectorAll('.scrollable');
-		scrollTestButtons.forEach(function(button) {
-			button.addEventListener('click', function() {
+		scrollTestButtons.forEach((button) => {
+			button.addEventListener('click', () => {
 				button.dispatchEvent(
 					new CustomEvent(
 						'd2l-navigation-band-slot-scroll-request',

--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -59,6 +59,7 @@ $_documentContainer.innerHTML = `<style>
 			}
 			div[slot="navigation-band"] {
 				white-space: nowrap;
+				position: relative; /* Needed for Firefox */
 			}
 			button {
 				height: 26px;


### PR DESCRIPTION
This is the first of three PRs adding the ability for the selected tab to be scrolled into view and centered.

Since we can't use `ScrollIntoView` because that moves the focus in Chrome, we need to tell the `d2l-navigation-scroll` element where we want to go.  But only the contents of the slot know where we want to go, so this PR adds the ability for the `d2l-navigation-band` to receive an event (`d2l-navigation-band-slot-scroll-request`) with the location of the point that the nav-band should try to center.