### PR TITLE
Remove tabstop on navigation-band in Firefox

### DIFF
--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -94,7 +94,7 @@ class D2LNavigationBand extends PolymerElement {
 			}
 		</style>
 		<div class="d2l-navigation-centerer">
-			<div class="d2l-navigation-scroll" custom-scroll$=[[customScroll]]>
+			<div class="d2l-navigation-scroll" custom-scroll$=[[customScroll]] tabindex="-1">
 				<div class="d2l-navigation-gutters">
 					<slot></slot>
 				</div>


### PR DESCRIPTION
When a div is scrollable, Firefox makes it a tab stop by default.  We don't want/need that functionality, so turning that off here.