### PR TITLE
De35352/Alt attribute on image with no link/text

### DIFF
--- a/d2l-navigation-link-image.js
+++ b/d2l-navigation-link-image.js
@@ -23,7 +23,8 @@ class D2LNavigationLinkImage extends PolymerElement {
 				value: false
 			},
 			text: {
-				type: String
+				type: String,
+				value: ''
 			}
 		};
 	}
@@ -52,7 +53,7 @@ class D2LNavigationLinkImage extends PolymerElement {
 			}
 		</style>
 		<d2l-navigation-link href="[[href]]" text="[[text]]">
-			<span class="d2l-navigation-link-image-container"><img src="[[src]]" alt="[[text]]"></span>
+			<span class="d2l-navigation-link-image-container"><img src="[[src]]" alt$="[[text]]"></span>
 		</d2l-navigation-link>`;
 		template.setAttribute('strip-whitespace', '');
 		return template;

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>d2l-navigation demo list</title>
+	</head>
+	<body>
+		<h1>Navigation Demo Pages</h1>
+		<ul>
+			<li><a href="navigation.html">navigation</a></li>
+			<li><a href="navigation-band.html">navigation-band</a></li>
+			<li><a href="d2l-navigation-button.html">navigation-button</a></li>
+			<li><a href="navigation-immersive.html">navigation-immersive</a></li>
+			<li><a href="d2l-navigation-iterator.html">navigation-iterator</a></li>
+			<li><a href="d2l-navigation-link-iterator.html">navigation-link-iterator</a></li>
+			<li><a href="navigation-main-footer.html">navigation-main-footer</a></li>
+			<li><a href="navigation-main-header.html">navigation-main-header</a></li>
+			<li><a href="navigation-separator.html">navigation-separator</a></li>
+		</ul>
+	</body>
+</html>

--- a/test/d2l-navigation-button.html
+++ b/test/d2l-navigation-button.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-navigation-separator test</title>
+		<title>d2l-navigation-button test</title>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../d2l-navigation-button.js"></script>
@@ -47,6 +47,11 @@
 		<test-fixture id="imageLink">
 			<template strip-whitespace>
 				<d2l-navigation-link-image href="https://www.example.org" src="testSrc" text="image alt text"></d2l-navigation-link-image>
+			</template>
+		</test-fixture>
+		<test-fixture id="imageLinkUndefinedText">
+			<template strip-whitespace>
+				<d2l-navigation-link-image href="https://www.example.org" src="testSrc"></d2l-navigation-link-image>
 			</template>
 		</test-fixture>
 
@@ -256,6 +261,18 @@ suite('d2l-navigation-link-image', function() {
 	test('should pass text down to the base link', function() {
 		var text = dom(button.root).querySelector('d2l-navigation-link').text;
 		assert.equal(button.text, text);
+	});
+});
+
+suite('d2l-navigation-link-image undefined text', function() {
+	setup(function() {
+		button = fixture('imageLinkUndefinedText');
+	});
+	testInstantiation('d2l-navigation-link-image');
+	test('should have empty alt when text attribute is missing or an empty string', function() {
+		var img = dom(button.root).querySelector('img');
+		assert.equal(img.hasAttribute('alt'), true);
+		assert.equal(img.getAttribute('alt'), '');
 	});
 });
 </script>

--- a/test/d2l-navigation-button.html
+++ b/test/d2l-navigation-button.html
@@ -62,7 +62,6 @@ import '../d2l-navigation-button-close.js';
 import '../d2l-navigation-link.js';
 import '../d2l-navigation-link-back.js';
 import '../d2l-navigation-link-image.js';
-import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
 let button;
 function testInstantiation(name) {
 	test('instantiating the element works', () => {
@@ -265,7 +264,7 @@ suite('d2l-navigation-link-image', () => {
 });
 
 suite('d2l-navigation-link-image undefined text', () => {
-	setup( () => {
+	setup(() => {
 		button = fixture('imageLinkUndefinedText');
 	});
 	testInstantiation('d2l-navigation-link-image');

--- a/test/d2l-navigation-button.html
+++ b/test/d2l-navigation-button.html
@@ -63,9 +63,9 @@ import '../d2l-navigation-link.js';
 import '../d2l-navigation-link-back.js';
 import '../d2l-navigation-link-image.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
-var button;
+let button;
 function testInstantiation(name) {
-	test('instantiating the element works', function() {
+	test('instantiating the element works', () => {
 		assert.equal(button.tagName.toLowerCase(), name);
 	});
 }
@@ -74,203 +74,203 @@ function getStyle(el, property) {
 	return window.getComputedStyle(el).getPropertyValue(property).trim();
 }
 
-suite('d2l-navigation-button', function() {
-	setup(function() {
+suite('d2l-navigation-button', () => {
+	setup(() => {
 		button = fixture('baseButton');
 	});
 	testInstantiation('d2l-navigation-button');
-	test('should have title equal to text', function() {
-		var title = button.$$('button').getAttribute('title');
+	test('should have title equal to text', () => {
+		const title = button.$$('button').getAttribute('title');
 		assert.equal(button.text, 'base button alt text');
 		assert.equal(button.text, title);
 	});
-	test('text attribute should reflect changes to text property', function() {
+	test('text attribute should reflect changes to text property', () => {
 		button.text = 'newText';
 		assert.equal(button.getAttribute('text'), 'newText');
 	});
-	test('text property should reflect changes to text attribute', function() {
+	test('text property should reflect changes to text attribute', () => {
 		button.setAttribute('text', 'newText');
 		assert.equal(button.text, 'newText');
 	});
 });
 
-suite('d2l-navigation-button-notification-icon', function() {
-	setup(function() {
+suite('d2l-navigation-button-notification-icon', () => {
+	setup(() => {
 		button = fixture('iconButton');
 	});
 	testInstantiation('d2l-navigation-button-notification-icon');
-	test('should have icon, text, notification, and notification-text', function() {
+	test('should have icon, text, notification, and notification-text', () => {
 		assert.equal(button.icon, 'testIcon');
 		assert.equal(button.text, 'icon alt text');
 		assert.equal(button.notification, true);
 		assert.equal(button.notificationText, 'notification text');
 	});
-	test('icon property should reflect changes to icon attribute', function() {
+	test('icon property should reflect changes to icon attribute', () => {
 		button.setAttribute('icon', 'newIcon');
 		assert.equal(button.icon, 'newIcon');
 	});
-	test('notification property should reflect changes to notification attribute', function() {
+	test('notification property should reflect changes to notification attribute', () => {
 		button.removeAttribute('notification');
 		assert.equal(button.notification, false);
 	});
-	test('notification attribute should reflect changes to notification property', function() {
+	test('notification attribute should reflect changes to notification property', () => {
 		button.notification = false;
 		assert.equal(button.getAttribute('notification'), null);
 	});
-	test('notificationText property should reflect changes to notification-text attribute', function() {
+	test('notificationText property should reflect changes to notification-text attribute', () => {
 		button.setAttribute('notification-text', 'newText');
 		assert.equal(button.notificationText, 'newText');
 	});
-	test('should pass text down to the base button', function() {
-		var title = button.$$('d2l-navigation-button').text;
+	test('should pass text down to the base button', () => {
+		const title = button.$$('d2l-navigation-button').text;
 		assert.equal(button.text, title);
 	});
-	test('should pass notificationText property to offscreen span', function() {
-		var nText = button.$$('d2l-navigation-button').$$('.d2l-offscreen-description').innerHTML;
+	test('should pass notificationText property to offscreen span', () => {
+		const nText = button.$$('d2l-navigation-button').$$('.d2l-offscreen-description').innerHTML;
 		assert.equal(button.notificationText, nText);
 	});
-	test('should NOT pass notificationText property if the notification attribute is not present', function() {
+	test('should NOT pass notificationText property if the notification attribute is not present', () => {
 		button.removeAttribute('notification');
-		var nText = button.$$('d2l-navigation-button').$$('.d2l-offscreen-description').innerHTML;
+		const nText = button.$$('d2l-navigation-button').$$('.d2l-offscreen-description').innerHTML;
 		assert.equal('', nText);
 	});
-	test('notification icon should not change colour on focus', function() {
-		var btn = button.shadowRoot.querySelector('d2l-navigation-button').shadowRoot.querySelector('button');
-		var icon = button.shadowRoot.querySelector('d2l-navigation-notification-icon').shadowRoot.querySelector('.d2l-navigation-notification-icon-indicator');
+	test('notification icon should not change colour on focus', () => {
+		const btn = button.shadowRoot.querySelector('d2l-navigation-button').shadowRoot.querySelector('button');
+		const icon = button.shadowRoot.querySelector('d2l-navigation-notification-icon').shadowRoot.querySelector('.d2l-navigation-notification-icon-indicator');
 		assert.oneOf(getStyle(icon, 'background-color'), ['rgb(232, 117, 17)', '#e87511']);
 		btn.focus();
 		assert.oneOf(getStyle(icon, 'background-color'), ['rgb(232, 117, 17)', '#e87511']);
 	});
 });
 
-suite('d2l-navigation-button-close', function() {
-	setup(function() {
+suite('d2l-navigation-button-close', () => {
+	setup(() => {
 		button = fixture('closeButton');
 	});
 	testInstantiation('d2l-navigation-button-close');
-	test('should pass text down to the base button', function() {
-		var title = button.$$('d2l-navigation-button-notification-icon').text;
+	test('should pass text down to the base button', () => {
+		const title = button.$$('d2l-navigation-button-notification-icon').text;
 		assert.equal('Close', title);
 	});
 });
 
-suite('d2l-navigation-link', function() {
-	setup(function() {
+suite('d2l-navigation-link', () => {
+	setup(() => {
 		button = fixture('baseLink');
 	});
 	testInstantiation('d2l-navigation-link');
-	test('should have an href', function() {
-		var anchorHref = button.$$('a').getAttribute('href');
+	test('should have an href', () => {
+		const anchorHref = button.$$('a').getAttribute('href');
 		assert.equal(button.href, 'https://www.example.org');
 		assert.equal(button.href, anchorHref);
 	});
-	test('href attribute should reflect changes to href property', function() {
+	test('href attribute should reflect changes to href property', () => {
 		button.href = 'newHref';
 		assert.equal(button.getAttribute('href'), 'newHref');
 	});
-	test('href property should reflect changes to href attribute', function() {
+	test('href property should reflect changes to href attribute', () => {
 		button.setAttribute('href', 'newHref');
 		assert.equal(button.href, 'newHref');
 	});
-	test('should have a text property', function() {
-		var anchorTitle = button.$$('a').getAttribute('title');
+	test('should have a text property', () => {
+		const anchorTitle = button.$$('a').getAttribute('title');
 		assert.equal(button.text, 'link alt text');
 		assert.equal(button.text, anchorTitle);
 	});
-	test('text property should reflect changes to text attribute', function() {
+	test('text property should reflect changes to text attribute', () => {
 		button.setAttribute('text', 'newText');
 		assert.equal(button.text, 'newText');
 	});
 });
 
-suite('d2l-navigation-link-back', function() {
-	setup(function() {
+suite('d2l-navigation-link-back', () => {
+	setup(() => {
 		button = fixture('backLink');
 	});
 	testInstantiation('d2l-navigation-link-back');
-	test('should have text and href', function() {
+	test('should have text and href', () => {
 		assert.equal(button.text, 'Back Button');
 		assert.equal(button.href, 'https://www.example.org');
 	});
-	test('text property should reflect changes to text attribute', function() {
+	test('text property should reflect changes to text attribute', () => {
 		button.setAttribute('text', 'New Text');
 		assert.equal(button.text, 'New Text');
 	});
-	test('should use default text when text property is null', function() {
+	test('should use default text when text property is null', () => {
 		button.text = null;
-		var text = button.$$('span').innerHTML;
+		const text = button.$$('span').innerHTML;
 		assert.equal(text, 'Back');
 	});
-	test('should omit text when text property is an empty string', function() {
+	test('should omit text when text property is an empty string', () => {
 		button.text = '';
-		var text = button.$$('span').innerHTML;
+		const text = button.$$('span').innerHTML;
 		assert.equal(text, '');
 	});
-	test('should omit text when text attribute is an empty string', function() {
+	test('should omit text when text attribute is an empty string', () => {
 		button.setAttribute('text', '');
-		var text = button.$$('span').innerHTML;
+		const text = button.$$('span').innerHTML;
 		assert.equal(text, '');
 	});
-	test('should pass href down to the base link', function() {
-		var href = dom(button.root).querySelector('d2l-navigation-link').href;
+	test('should pass href down to the base link', () => {
+		const href = button.shadowRoot.querySelector('d2l-navigation-link').href;
 		assert.equal(button.href, href);
 	});
-	test('should pass text down to the base link', function() {
-		var text = button.$$('d2l-navigation-link').text;
+	test('should pass text down to the base link', () => {
+		const text = button.$$('d2l-navigation-link').text;
 		assert.equal(text, 'Back Button');
 	});
 });
 
-suite('d2l-navigation-link-back undefined text', function() {
-	setup(function() {
+suite('d2l-navigation-link-back undefined text', () => {
+	setup(() => {
 		button = fixture('backLinkUndefinedText');
 	});
 	testInstantiation('d2l-navigation-link-back');
-	test('should use default text when text property is undefined', function() {
-		var text = button.$$('span').innerHTML;
+	test('should use default text when text property is undefined', () => {
+		const text = button.$$('span').innerHTML;
 		assert.equal(text, 'Back');
 	});
-	test('should pass default text down to the base link', function() {
-		var text = button.$$('d2l-navigation-link').text;
+	test('should pass default text down to the base link', () => {
+		const text = button.$$('d2l-navigation-link').text;
 		assert.equal(text, 'Back');
 	});
 });
 
-suite('d2l-navigation-link-image', function() {
-	setup(function() {
+suite('d2l-navigation-link-image', () => {
+	setup(() => {
 		button = fixture('imageLink');
 	});
 	testInstantiation('d2l-navigation-link-image');
-	test('should have src, href and text', function() {
+	test('should have src, href and text', () => {
 		assert.equal(button.src, 'testSrc');
 		assert.equal(button.href, 'https://www.example.org');
 		assert.equal(button.text, 'image alt text');
 	});
-	test('src property should reflect changes to src attribute', function() {
+	test('src property should reflect changes to src attribute', () => {
 		button.setAttribute('src', 'newSrc');
 		assert.equal(button.src, 'newSrc');
 	});
-	test('should pass href down to the base link', function() {
-		var href = dom(button.root).querySelector('d2l-navigation-link').href;
+	test('should pass href down to the base link', () => {
+		const href = button.shadowRoot.querySelector('d2l-navigation-link').href;
 		assert.equal(button.href, href);
 	});
-	test('should pass text down to image alt text', function() {
-		var alt = dom(button.root).querySelector('img').getAttribute('alt');
+	test('should pass text down to image alt text', () => {
+		const alt = button.shadowRoot.querySelector('img').getAttribute('alt');
 		assert.equal(button.text, alt);
 	});
-	test('should pass text down to the base link', function() {
-		var text = dom(button.root).querySelector('d2l-navigation-link').text;
+	test('should pass text down to the base link', () => {
+		const text = button.shadowRoot.querySelector('d2l-navigation-link').text;
 		assert.equal(button.text, text);
 	});
 });
 
-suite('d2l-navigation-link-image undefined text', function() {
-	setup(function() {
+suite('d2l-navigation-link-image undefined text', () => {
+	setup( () => {
 		button = fixture('imageLinkUndefinedText');
 	});
 	testInstantiation('d2l-navigation-link-image');
-	test('should have empty alt when text attribute is missing or an empty string', function() {
-		var img = dom(button.root).querySelector('img');
+	test('should have empty alt when text attribute is missing or an empty string', () => {
+		const img = button.shadowRoot.querySelector('img');
 		assert.equal(img.hasAttribute('alt'), true);
 		assert.equal(img.getAttribute('alt'), '');
 	});

--- a/test/d2l-navigation-iterator-item.html
+++ b/test/d2l-navigation-iterator-item.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-navigation-iterator test</title>
+		<title>d2l-navigation-iterator-item test</title>
 		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../components/d2l-navigation-iterator/d2l-navigation-iterator-item.js"></script>


### PR DESCRIPTION
- Added an index for the list of demo pages
- When passed an empty text value or missing text prop, `d2l-navigation-link-image` now creates inner `<img>` tag with `alt` attribute.
- Added test to confirm the above
- Refactored the button tests
- Tested code changes with BSI on a local lms instance