### PR TITLE
Fix nav bar visible-on-ancestor for the Polymer to Lit dropdown conversion

### DIFF
--- a/d2l-navigation-main-footer.js
+++ b/d2l-navigation-main-footer.js
@@ -20,7 +20,7 @@ class D2LNavigationMainFooter extends PolymerElement {
 					display: block;
 				}
 			</style>
-			<div class="d2l-navigation-centerer d2l-visible-on-ancestor-target">
+			<div class="d2l-navigation-centerer">
 				<div class="d2l-navigation-gutters">
 					<slot name="main"></slot>
 				</div>

--- a/test/navigation-main-footer.html
+++ b/test/navigation-main-footer.html
@@ -26,10 +26,6 @@ suite('d2l-navigation-main-footer', function() {
 		expect(centerer).to.not.be.null;
 		assert.equal(centerer.tagName, 'DIV');
 
-		var ancestor = dom(footer.root).querySelector('.d2l-visible-on-ancestor-target');
-		expect(ancestor).to.not.be.null;
-		assert.equal(ancestor.tagName, 'DIV');
-
 		var gutters = dom(footer.root).querySelector('.d2l-navigation-gutters');
 		expect(gutters).to.not.be.null;
 		assert.equal(gutters.tagName, 'DIV');


### PR DESCRIPTION
# Issue
In the nav bar, the `visible-on-ancestor` functionality broke because the Lit version loads faster than the Polymer version. This means that when the `visible-on-ancestor-mixin` uses [`findComposedAncestor`](https://github.com/BrightspaceUI/core/blob/master/mixins/visible-on-ancestor-mixin.js#L104), the parent element has loaded but its shadow DOM has not. Because the `d2l-visible-on-ancestor-target` is hidden within the ancestor's shadow DOM, the look up fails.

# Fix
To fix this, `d2l-visible-on-ancestor-target` needs to be
moved outside of the ancestor's shadow DOM into the light DOM.