### PR TITLE
Support a new `width-type` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyf
 Then add the `d2l-navigation-immersive`, providing values for the `backLinkHref` & `backLinkText`. Additionally, you may override any of the 3 slots (`left`, `middle`, `right`).
 Please note that overridding the `left` slot will prevent the Back link from displaying. This should only be done in very specialized cases.
 
-`d2l-navigation-immersive` can optionally have its max-width constrained to `1230px` by including the attribute `width-type="normal"`
+Optionally, the max-width can be configured to match the max-width used by the LE by setting `widthType` to `normal`.
 
 <!---
 ```

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Include the [webcomponents.js](http://webcomponents.org/polyfills/) "lite" polyf
 Then add the `d2l-navigation-immersive`, providing values for the `backLinkHref` & `backLinkText`. Additionally, you may override any of the 3 slots (`left`, `middle`, `right`).
 Please note that overridding the `left` slot will prevent the Back link from displaying. This should only be done in very specialized cases.
 
-`d2l-navigation-immersive` can optionally have a max width set to match your content.  Simply set the `--d2l-navigation-immersive-content-max-width` css variable to your desired width.
+`d2l-navigation-immersive` can optionally have its max-width constrained to `1230px` by including the attribute `width-type="normal"`
 
 <!---
 ```

--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -16,6 +16,15 @@ Polymer-based web component for the immersive navigation component
 */
 class D2LNavigationImmsersive extends PolymerElement {
 
+	static get properties() {
+		return {
+			widthType: {
+				type: String,
+				observer: '_widthTypeChanged'
+			}
+		};
+	}
+
 	static get template() {
 		const template = html`
 				${navigationSharedStyle}
@@ -245,6 +254,19 @@ class D2LNavigationImmsersive extends PolymerElement {
 				fastdom.mutate(function() {
 					container.classList.remove(containerClass);
 				});
+			}
+		}
+	}
+
+	_widthTypeChanged(widthType) {
+		if (widthType) {
+			const elem = dom(this.root).querySelector('.d2l-navigation-immersive-container');
+			switch (this.widthType) {
+				case 'normal':
+					elem.style.maxWidth = '1230px';
+					break;
+				case 'fullscreen':
+					elem.style.maxWidth = '100%';
 			}
 		}
 	}

--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -20,7 +20,7 @@ class D2LNavigationImmsersive extends PolymerElement {
 		return {
 			widthType: {
 				type: String,
-				observer: '_widthTypeChanged'
+				reflectToAttribute: true
 			}
 		};
 	}
@@ -55,9 +55,13 @@ class D2LNavigationImmsersive extends PolymerElement {
 				height: var(--d2l-navigation-immersive-height-main);
 				justify-content: space-between;
 				margin: 0 -7px;
-				max-width: var(--d2l-navigation-immersive-content-max-width, 100%);
+				max-width: 100%;
 				overflow: hidden;
 				width: 100%;
+			}
+
+			:host([width-type="normal"]) .d2l-navigation-immersive-container {
+				max-width: 1230px;
 			}
 
 			.d2l-navigation-immersive-left ::slotted(*),
@@ -254,19 +258,6 @@ class D2LNavigationImmsersive extends PolymerElement {
 				fastdom.mutate(function() {
 					container.classList.remove(containerClass);
 				});
-			}
-		}
-	}
-
-	_widthTypeChanged(widthType) {
-		if (widthType) {
-			const elem = dom(this.root).querySelector('.d2l-navigation-immersive-container');
-			switch (this.widthType) {
-				case 'normal':
-					elem.style.maxWidth = '1230px';
-					break;
-				case 'fullscreen':
-					elem.style.maxWidth = '100%';
 			}
 		}
 	}

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots-width-type-normal.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots-width-type-normal.html
@@ -25,9 +25,6 @@ const $_documentContainer = document.createElement('template');
 
 $_documentContainer.innerHTML = `<custom-style>
 			<style is="custom-style" include="demo-pages-shared-styles">
-				html {
-					--d2l-navigation-immersive-content-max-width: 900px;
-				}
 				body {
 					background-color: pink;
 					padding: 0;
@@ -81,7 +78,7 @@ const $_documentContainer = document.createElement('template');
 $_documentContainer.innerHTML = `<div class="vertical-section-container centered" style="max-width: 900px;">
 			<demo-snippet>
 				<template strip-whitespace="">
-					<d2l-navigation-immersive back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
+					<d2l-navigation-immersive width-type="normal" back-link-href="https://www.d2l.com" back-link-text="Back to D2L">
 						<div id="middle" class="d2l-typography d2l-body-standard" slot="middle">
 							Economics 101
 						</div>

--- a/demo/navigation-immersive.html
+++ b/demo/navigation-immersive.html
@@ -74,8 +74,8 @@ $_documentContainer.innerHTML = `<div>
 			<h3>d2l-navigation-immersive (no middle slot, no right slot)</h3>
 			<iframe src="./navigation-immersive-demos/navigation-immersive-no-slots.html"></iframe>
 
-			<h3> d2l-navigation-immersive optional max width (900px)</h3>
-			<iframe src="./navigation-immersive-demos/navigation-immersive-all-slots-max-width.html"></iframe>
+			<h3> d2l-navigation-immersive width-type set to normal instead of fullscreen</h3>
+			<iframe src="./navigation-immersive-demos/navigation-immersive-all-slots-width-type-normal.html"></iframe>
 		</div>`;
 
 document.body.appendChild($_documentContainer.content);


### PR DESCRIPTION
The user may now apply a `width-type` attribute on `d2l-navigation-immersive` with the value `normal`.
`normal` restricts the nav bar left/middle/right to fit a max-width of `1230px`.

The existing CSS variable, `--d2l-navigation-immersive-content-max-width` which allowed the user to configure the width to be any value will be removed. Usages of the existing CSS variable (2 places) will be updated accordingly to use the new attribute.