### PR TITLE
deploying as a separate stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ jobs:
         echo "Not a pull request and/or no secure environment variables, running headless tests...";
         npm run test:polymer:local || travis_terminate 1;
       fi
+    env:
+      - SAUCE_USERNAME: Desire2Learn
+      # SAUCE_ACCESS_KEY
+      - secure: j7N5Mth+AY+MObVwsysDBWs8musd84uAcynODmnm3MmDin0yrG0HY63FBh9vKSqyOeu/pR4r6hcvMiQfybE37NK0HeeENMvanEAIIdqCdGPNGLU3OTu1W/Tci9XEVV9NdFDeZuVTU8+d1IaHPAMOPeWDBka3mNe1un9KSaiPSTyktIjxboR1k3mQ2ESUAyu5qW0UGeUQzWywNYZ1a6KbrpjhdjcSJ/kxwg4EDgsLZeI7QTQtx+jKDZPiCYH5b237dp0+to7kMMHmw37AQRnxfOayT7AhRKcgJh6snX3FgqdaOpgk0iZ/xldIqWBSPc7HEm/ZvLqq51kxUSdE4PCAiunARxo7GBnOXlYd9pGYYnFsn9vQrnPvp3WK1dGdCIQmDOq09z2C9Jh0End/xjB2lky7+FYK8g5tqxoz6gsHI80FHtY2uWwLo6MNGk38//9c980Q+XpK8G+qEZ+gfx8QnGsMg5Yl7NoXwEiJ9FmaQ2vRsybnCA/9OTHnPXWG3o1d4yNhVRRGUSnzUtuBJXPxmHhUxrVrYkYE/7pMmZjtkQH9P11uYcLXZsKaXlDd+m7yfY7rQXXZFslVuKS7LWcLWrbW3BHg0NwxrVrqi5NsttdU8vDlWgS3j1q+2tH5AgfRHn6T6aymXz/Vhv4pN7AVslu6I1Pdf6souyb56RUg/8o=
   - stage: visual-difference-tests
     script:
     - |
@@ -24,24 +28,22 @@ jobs:
         echo "Running visual difference tests...";
         npm run test:diff || travis_terminate 1;
       fi
-after_success:
-- |
-  if [ $TRAVIS_BUILD_STAGE_NAME == "Visual-difference-tests" ]; then
-    frauci-update-version -d=skip && export TRAVIS_TAG=$(frauci-get-version)
-  fi
-deploy:
-  provider: releases
-  api_key: "$GITHUB_RELEASE_TOKEN"
-  on:
-    tags: true
+    env:
+      # VISUAL_DIFF_S3_ID
+      - secure: G5IwSDEi8SQNalS80NO12W34vGrQT810kSbOhAYKCB90LYlKvKnz3GZ/oW6BiRxFx+73KyI5htPVwX5LEOAUzCAdpH+vdTE1q/OZttZH6JHm9FKIB2ttdjyeV5G+nvJWyfXdN+LLLkzkHLvh6cen7SXy4NEEoga8EafE6h7Gn93bsw9E+Z1YqrJjJqY+rj2N6IG+BqZaaBg9QFub/mi71LApi9iRxQuUp65vXJWu+n67oCvHhGxnelrkIK93NUxWZttH0gd8ZcFNVrTN6RB2vS4kvD4GzkcFY/h86iy771Rc5uDrEGBFvr0VRSWifmFrJ1mcDk+bxs75Wh0/CwNFwywZAKC00z/xYuoVgOciBUaUGZWWiljOOownSb3k+PGnju1u6TisSAa4PZPaOfbSE0TvdsIbdjeE0+ymM8n5hE8hP0+6bikBQMdnxffav54BMJfTr2dgaDknl+JnuovCLA0/x1S5k8oYH7/PxKsiw/l9jI8KymvYP/faJ4xuuYrL8Vbd1Xt4OxUK0WLJuXPhcsJLC6T+Qm1fG3OjFzx2ibnhTRGbHumksJSoi31tzLrw8J4lwQdr300QQD0GEW5z8nmhW0TQ47KTvcd+gxs2u5rDQHzuFzxSD//c3NamDyyOJ8M6mr3IHxS4ULAxmzEXAOBNMLlN04NTyN0UrO5YCsk=
+      # VISUAL_DIFF_S3_SECRET
+      - secure: o44zo1FX/l2O9Ss3qaKnu3+LGUs+/2Hre7CTKfHXPwblY0LZmchiKiOw6R7O8P66f8jCQkLLwJo75yAm23CZWPae8WMn30DLw8HQaS9z4Y40NhrYIpLPWBM0QNCLloj977Oag+6CgSy00XyF5tssGiuKDDJJ40w0qKYdxhE0lmeqBjtOmLZiYLevD6q8CnSzm14lsuVx6taB2499prEFwdD5hQFjKwvv95t0DrxuFpkSl/aLQQauVEp+vLP3CAOKLmybh8u3gM+AKzwwbNu1SszD//zlmVaJNziUds179HS5xt4ODMEvOFMWeTGK8IKcFcwc+duxz2YNRSb04x4S/9l5OfwMsCNzNGcKDYWjUuTxEc6I/lziwaZl2NfSxMRv0DK+dIpz7tQCc4GnoVQxoQoUu1P+qXgdprkrRzZBZWb7ymJ0ijdgi2Up6+V2XSUdFZ/nXEnMB8y7ltr4bi5ZqSJD5A5TNFr0kw0dX9mExSSADI1bVWF1nHNMEfC+PZaYHqICEv6jOG+faYRZXZap0GSJ8GU32izg57IV4D9fqvsWANGCEbWtqwa8mizZF8CmZ6JaYffulX2bg2SuQU9MXY160YlkFJjy0xoEjcmy4Oz2fH8+nvUYHSCE6B6SI9nZ19lvGqBk9Y0HCGJOoBthk0dTUtbYyjJz4jn6UevBC/c=
+  - stage: deploy
+    after_success: frauci-update-version -d=skip && export TRAVIS_TAG=$(frauci-get-version)
+    env:
+      - OWNER_NAME=BrightspaceUI
+      - REPO_NAME=navigation
+    deploy:
+      provider: releases
+      api_key: "$GITHUB_RELEASE_TOKEN"
+      on:
+        tags: true
 env:
   global:
-  - OWNER_NAME=BrightspaceUI
-  - REPO_NAME=navigation
-  - SAUCE_USERNAME: Desire2Learn
-  - secure: j7N5Mth+AY+MObVwsysDBWs8musd84uAcynODmnm3MmDin0yrG0HY63FBh9vKSqyOeu/pR4r6hcvMiQfybE37NK0HeeENMvanEAIIdqCdGPNGLU3OTu1W/Tci9XEVV9NdFDeZuVTU8+d1IaHPAMOPeWDBka3mNe1un9KSaiPSTyktIjxboR1k3mQ2ESUAyu5qW0UGeUQzWywNYZ1a6KbrpjhdjcSJ/kxwg4EDgsLZeI7QTQtx+jKDZPiCYH5b237dp0+to7kMMHmw37AQRnxfOayT7AhRKcgJh6snX3FgqdaOpgk0iZ/xldIqWBSPc7HEm/ZvLqq51kxUSdE4PCAiunARxo7GBnOXlYd9pGYYnFsn9vQrnPvp3WK1dGdCIQmDOq09z2C9Jh0End/xjB2lky7+FYK8g5tqxoz6gsHI80FHtY2uWwLo6MNGk38//9c980Q+XpK8G+qEZ+gfx8QnGsMg5Yl7NoXwEiJ9FmaQ2vRsybnCA/9OTHnPXWG3o1d4yNhVRRGUSnzUtuBJXPxmHhUxrVrYkYE/7pMmZjtkQH9P11uYcLXZsKaXlDd+m7yfY7rQXXZFslVuKS7LWcLWrbW3BHg0NwxrVrqi5NsttdU8vDlWgS3j1q+2tH5AgfRHn6T6aymXz/Vhv4pN7AVslu6I1Pdf6souyb56RUg/8o=
+  # GITHUB_RELEASE_TOKEN
   - secure: K7KV8E3R4KSguZlMbXDxFTtSYWJYv5enPutjbXQdPrJ1kbRRAI/xRnRomNRXHtFOp9+FwysXXdrCV5ELvgPX85TfyjW+UiKFycq12gun2gKi5CrH7V4guP0m3MT+Ebcl/qC6ppPU9ey+9po+cw9M27unfIGJgqcfid32cQ3CdPXbQmX0VIu41E2rkx+PAh4E/GDHCk/DB2T9pKJkKwZMgmkzGF+a2/2saRagGirbAzfpooc4+WL6E7/6WONvPl9yCmO6lDBpGYad98HqYUC8AAS0h57vKeUKew92RNpJgl0QYvC5kV5bUgK2g0bVABRL8JvT8Ooyn7TZE1LY7DBrNDTqlayD5B8y4Xo/JfhHSsIZTQ/WK8gxy/JOk0OaDBEVCz8DYw1OjWLL4RsWMm/yNuaDvNANNT90V2mcLmFYR6yEI+3RW1AIMDpqD/s2ceNfmdV95D9ZU86AUMTpOxzrN4DIHLM8GOwXEA/u0pKh0FtLREEW28HudlIOzVlxqAA8a94y+T6YciktfSCVTYqrqTt+WTT6gCUzgUAPxUqZYNalPvRimlcj1f4XmNZhHEtXtXGlbXv1oZPKQdF0l26Lwdf24Ei2M2NABHm0QUyEGHts8CARewSEtpWnZZJ4IMSzzeZN5BeOhVecCgSDZgFrnoA5zJnnavwH8E9JcCrH68U=
-  # VISUAL_DIFF_S3_ID
-  - secure: G5IwSDEi8SQNalS80NO12W34vGrQT810kSbOhAYKCB90LYlKvKnz3GZ/oW6BiRxFx+73KyI5htPVwX5LEOAUzCAdpH+vdTE1q/OZttZH6JHm9FKIB2ttdjyeV5G+nvJWyfXdN+LLLkzkHLvh6cen7SXy4NEEoga8EafE6h7Gn93bsw9E+Z1YqrJjJqY+rj2N6IG+BqZaaBg9QFub/mi71LApi9iRxQuUp65vXJWu+n67oCvHhGxnelrkIK93NUxWZttH0gd8ZcFNVrTN6RB2vS4kvD4GzkcFY/h86iy771Rc5uDrEGBFvr0VRSWifmFrJ1mcDk+bxs75Wh0/CwNFwywZAKC00z/xYuoVgOciBUaUGZWWiljOOownSb3k+PGnju1u6TisSAa4PZPaOfbSE0TvdsIbdjeE0+ymM8n5hE8hP0+6bikBQMdnxffav54BMJfTr2dgaDknl+JnuovCLA0/x1S5k8oYH7/PxKsiw/l9jI8KymvYP/faJ4xuuYrL8Vbd1Xt4OxUK0WLJuXPhcsJLC6T+Qm1fG3OjFzx2ibnhTRGbHumksJSoi31tzLrw8J4lwQdr300QQD0GEW5z8nmhW0TQ47KTvcd+gxs2u5rDQHzuFzxSD//c3NamDyyOJ8M6mr3IHxS4ULAxmzEXAOBNMLlN04NTyN0UrO5YCsk=
-  # VISUAL_DIFF_S3_SECRET
-  - secure: o44zo1FX/l2O9Ss3qaKnu3+LGUs+/2Hre7CTKfHXPwblY0LZmchiKiOw6R7O8P66f8jCQkLLwJo75yAm23CZWPae8WMn30DLw8HQaS9z4Y40NhrYIpLPWBM0QNCLloj977Oag+6CgSy00XyF5tssGiuKDDJJ40w0qKYdxhE0lmeqBjtOmLZiYLevD6q8CnSzm14lsuVx6taB2499prEFwdD5hQFjKwvv95t0DrxuFpkSl/aLQQauVEp+vLP3CAOKLmybh8u3gM+AKzwwbNu1SszD//zlmVaJNziUds179HS5xt4ODMEvOFMWeTGK8IKcFcwc+duxz2YNRSb04x4S/9l5OfwMsCNzNGcKDYWjUuTxEc6I/lziwaZl2NfSxMRv0DK+dIpz7tQCc4GnoVQxoQoUu1P+qXgdprkrRzZBZWb7ymJ0ijdgi2Up6+V2XSUdFZ/nXEnMB8y7ltr4bi5ZqSJD5A5TNFr0kw0dX9mExSSADI1bVWF1nHNMEfC+PZaYHqICEv6jOG+faYRZXZap0GSJ8GU32izg57IV4D9fqvsWANGCEbWtqwa8mizZF8CmZ6JaYffulX2bg2SuQU9MXY160YlkFJjy0xoEjcmy4Oz2fH8+nvUYHSCE6B6SI9nZ19lvGqBk9Y0HCGJOoBthk0dTUtbYyjJz4jn6UevBC/c=


### PR DESCRIPTION
This switches the deployment to be a separate stage, which allows us to avoid the check to only run it in the visual-diff stage. It also lets us restrict the encrypted variables to the stages for which they're required.