### PR TITLE
restoring back-link-href and back-link-text properties

### DIFF
--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -18,6 +18,14 @@ class D2LNavigationImmsersive extends PolymerElement {
 
 	static get properties() {
 		return {
+			backLinkHref: {
+				type: String,
+				reflectToAttribute: true
+			},
+			backLinkText: {
+				type: String,
+				reflectToAttribute: true
+			},
 			widthType: {
 				type: String,
 				reflectToAttribute: true


### PR DESCRIPTION
Not sure how this happened, but these 2 properties were [accidentally deleted](https://github.com/BrightspaceUI/navigation/commit/74425b5736614d97a39e91cfc3322ab3ae4b5df0#diff-be945901e9cdfaab1afb2753c6bb090a) last July. Restoring them.