### PR TITLE
removing visible-on-ancestor parent from nav

### DIFF
--- a/d2l-navigation-main-footer.js
+++ b/d2l-navigation-main-footer.js
@@ -20,7 +20,7 @@ class D2LNavigationMainFooter extends PolymerElement {
 					display: block;
 				}
 			</style>
-			<div class="d2l-navigation-centerer d2l-visible-on-ancestor-target">
+			<div class="d2l-navigation-centerer">
 				<div class="d2l-navigation-gutters">
 					<slot name="main"></slot>
 				</div>

--- a/test/navigation-main-footer.html
+++ b/test/navigation-main-footer.html
@@ -26,10 +26,6 @@ suite('d2l-navigation-main-footer', function() {
 		expect(centerer).to.not.be.null;
 		assert.equal(centerer.tagName, 'DIV');
 
-		var ancestor = dom(footer.root).querySelector('.d2l-visible-on-ancestor-target');
-		expect(ancestor).to.not.be.null;
-		assert.equal(ancestor.tagName, 'DIV');
-
 		var gutters = dom(footer.root).querySelector('.d2l-navigation-gutters');
 		expect(gutters).to.not.be.null;
 		assert.equal(gutters.tagName, 'DIV');


### PR DESCRIPTION
We had a defect recently where the "..." more menu in the Brightspace navbar was suddenly always showing up and wasn't obeying the "visible-on-ancestor" behaviour.

Turns out the timing around how this stuff wires up is very delicate, and unbundled BSI builds were initializing faster such that `<d2l-navigation-main-footer>`'s shadow root wasn't available yet when the descendants initialized. The solution was to simply move the `visible-on-ancesator-target` CSS class to an element that isn't in the shadow root, [like this](https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/14251/overview).

In doing so, having it also be applied here isn't necessary. Also... I don't really think it's `navigation-main-footer`'s responsibility to even know about this, since it has no idea what's being put inside itself. If consumers want the behaviour, they should apply it to `d2l-navigation-main-footer` directly, which is what navbars is doing.

I checked and the [2 places using the footer](https://search.d2l.dev/search?project=GitHub&full=%22d2l-navigation-main-footer%22&defs=&refs=&path=&hist=&type=&xrd=) aren't relying on `visible-on-ancestor`.