### PR TITLE
prevent back link text & icon from wrapping

### DIFF
--- a/d2l-navigation-link-back.js
+++ b/d2l-navigation-link-back.js
@@ -53,6 +53,7 @@ class D2LNavigationLinkBack extends mixinBehaviors([D2L.PolymerBehaviors.Link.Be
 			:host {
 				display: inline-block;
 				height: 100%;
+				white-space: nowrap;
 			}
 			d2l-icon {
 				color: inherit;


### PR DESCRIPTION
Noticed that when things get tight, the back-link can wrap both inside the text but also the text can wrap on a different line from the back chevron icon. Since these are always used inside the navigation header, I don't think we ever want wrapping.