### PR TITLE
increasing z-index on immersive nav to be higher than skeleton loaders

### DIFF
--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -47,7 +47,7 @@ class D2LNavigationImmsersive extends PolymerElement {
 				position: fixed;
 				right: 0;
 				top: 0;
-				z-index: 1;
+				z-index: 2; /* higher than skeletons which could scroll behind immersive nav */
 			}
 			d2l-navigation {
 				border-bottom: 1px solid var(--d2l-color-mica);


### PR DESCRIPTION
@Vitalii-Misechko noticed that when immersive nav (`z-index: 1`) is used with skeleton loaders (`z-index: 1`), when you scroll the page such that the skeletons are "behind" the immersive nav, whichever rendered last "wins" the z-index tie and is displayed on top:

![image (1)](https://user-images.githubusercontent.com/5491151/94818283-ee86fb00-03cb-11eb-8821-3a558fd6d32d.png)

Increasing immersive nav to `z-index: 2` solves the problem. The band also uses `z-index: 2` for the scrolling gradient, but as far as I can tell bands with stuff inside them that might scroll and immersive nav can't be used together. Does that sound right Stacey?