### PR TITLE
d2l-navigation-button - Add property to remove top bar

### DIFF
--- a/d2l-navigation-button.js
+++ b/d2l-navigation-button.js
@@ -112,7 +112,7 @@ class D2LNavigationButton extends mixinBehaviors([D2L.PolymerBehaviors.Button.Be
 					}
 				</style>
 			<button aria-describedby$="[[_ariaDescriptionId]]" aria-expanded$="[[ariaExpanded]]" aria-haspopup$="[[ariaHaspopup]]" aria-label$="[[text]]" class="d2l-focusable" disabled$="[[disabled]]" autofocus$="[[autofocus]]" form$="[[form]]" formaction$="[[formaction]]" formenctype$="[[formenctype]]" formmethod$="[[formmethod]]" formnovalidate$="[[formnovalidate]]" formtarget$="[[formtarget]]" name$="[[name]]" title$="[[text]]" type$="[[type]]">
-			<span class$="[[_getTopBorderClass()]]" class="d2l-navigation-button-top-border"></span>
+			<span class$="[[_getTopBorderClass()]]"></span>
 			<slot></slot>
 			</button>
 			<span id="[[_ariaDescriptionId]]" class="d2l-offscreen-description">[[ariaDescribedbyText]]</span>

--- a/d2l-navigation-button.js
+++ b/d2l-navigation-button.js
@@ -20,6 +20,11 @@ class D2LNavigationButton extends mixinBehaviors([D2L.PolymerBehaviors.Button.Be
 				type: String,
 				reflectToAttribute: true
 			},
+			hideHighlight: {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
+			},
 			ariaDescribedbyText: {
 				type: String
 			},
@@ -107,13 +112,16 @@ class D2LNavigationButton extends mixinBehaviors([D2L.PolymerBehaviors.Button.Be
 					}
 				</style>
 			<button aria-describedby$="[[_ariaDescriptionId]]" aria-expanded$="[[ariaExpanded]]" aria-haspopup$="[[ariaHaspopup]]" aria-label$="[[text]]" class="d2l-focusable" disabled$="[[disabled]]" autofocus$="[[autofocus]]" form$="[[form]]" formaction$="[[formaction]]" formenctype$="[[formenctype]]" formmethod$="[[formmethod]]" formnovalidate$="[[formnovalidate]]" formtarget$="[[formtarget]]" name$="[[name]]" title$="[[text]]" type$="[[type]]">
-			<span class="d2l-navigation-button-top-border"></span>
+			<span class$="[[_getTopBorderClass()]]" class="d2l-navigation-button-top-border"></span>
 			<slot></slot>
 			</button>
 			<span id="[[_ariaDescriptionId]]" class="d2l-offscreen-description">[[ariaDescribedbyText]]</span>
 		`;
 		template.setAttribute('strip-whitespace', '');
 		return template;
+	}
+	_getTopBorderClass() {
+		return this.hideHighlight ? '' : 'd2l-navigation-button-top-border';
 	}
 	ready() {
 		super.ready();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13662408/97025389-0151a300-1526-11eb-978f-63ea0c71154b.png)

This is the default behavior on the iterator when hovering over the button. See the blue bar at the top

![image](https://user-images.githubusercontent.com/13662408/97025538-33fb9b80-1526-11eb-99ab-cd734efaa2db.png)

This is what design has asked for when the button is used not at the top of the page. No blue bar at the top