### PR TITLE
Adding a simple workflow to test the setup of the AWS role and token rotator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Test AWS Stuff
         run: |
-          node ${{ github.action_path }}/test-aws.js
+          node $GITHUB_WORKSPACE/.github/workflows/test-aws.js
         env:
           VISUAL_DIFF_S3_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           VISUAL_DIFF_S3_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,34 @@
+  
+# This workflow tests AWS stuff, and will be deleted after
+name: Testing
+on:
+  workflow_dispatch: #manual trigger
+
+jobs:
+  build:
+    # self-hosted doesn't work for public repos (security), so need to use ubuntu
+    runs-on: ubuntu-latest
+    
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout Repository
+        uses: Brightspace/third-party-actions@actions/checkout
+
+      - name: Use Node.js
+        uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '12.x'
+          
+      - name: Install Dependencies
+        run: npm i
+
+      - name: Test AWS Stuff
+        run: |
+          node ${{ github.action_path }}/test-aws.js
+        env:
+          VISUAL_DIFF_S3_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          VISUAL_DIFF_S3_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Done
+        run: git diff

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,6 @@ jobs:
         run: |
           node $GITHUB_WORKSPACE/.github/workflows/test-aws.js
         env:
-          VISUAL_DIFF_S3_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          VISUAL_DIFF_S3_SECRET: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-      - name: Done
-        run: git diff
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}

--- a/.github/workflows/test-aws.js
+++ b/.github/workflows/test-aws.js
@@ -1,0 +1,59 @@
+const AWS = require('aws-sdk');
+
+const getBucketCreds = async () => {
+    return new Promise((resolve, reject) => {
+        const timestamp = (new Date()).getTime();
+        const params = {
+        RoleArn: 'arn:aws:iam::661160317623:role/githubactions-visual-diff-testing',
+        RoleSessionName: `repo-visual-diff-testing-${timestamp}`
+        };
+        const sts = new AWS.STS();
+        sts.assumeRole(params, (err, data) => {
+        if (err) {
+            process.stdout.write(err.toString());
+            reject(err)
+        }
+        else {
+            resolve({
+            accessKeyId: data.Credentials.AccessKeyId,
+            secretAccessKey: data.Credentials.SecretAccessKey,
+            sessionToken: data.Credentials.SessionToken,
+            });
+        }
+        });
+    });
+}
+
+const getBucketContents = async () => {
+    let s3Config = {};
+    try {
+        s3Config = await getBucketCreds();
+    } catch(e) {
+        process.stdout.write(e);
+    }
+    s3Config.apiVersion = 'latest';
+    s3Config.region = 'ca-central-1';
+
+    const s3 = new AWS.S3(s3Config);
+    
+    return new Promise((resolve, reject) => {
+        s3.listObjects({ Bucket: 'visualdiff.gaudi.d2l' }, (err, data) => {
+            if (err) {
+                process.stdout.write(err.toString());
+                reject(err)
+            }
+            else {
+                process.stdout.write('we did it');
+                resolve(data.Contents[0]);
+            }
+            });
+    });
+}
+
+process.stdout.write('starting');
+
+getBucketContents().then((results) => {
+    process.stdout.write(JSON.stringify(results));
+}).catch((err) => {
+    process.stdout.write(err.toString());
+});


### PR DESCRIPTION
This will be deleted after I see everything is working, but I can't test this in my fork.  This tests whether I can assume the role successfully with the rotated secrets and then lists out the first item in the bucket (which should be the screenshots folder).