### PR TITLE
ci: remove visual-diff from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,3 @@ jobs:
         env:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY_DESIRE2LEARN }}
           SAUCE_USERNAME: Desire2Learn
-      - name: Visual Diff Tests
-        uses: BrightspaceUI/actions/visual-diff@master
-        with:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This was done as an experiment to see how the timing compared to having it in its separate `visual-diff.yml` workflow. We've decided we like having the separate workflow better as it allows the tests to run in parallel and they can also be re-runnable.