### PR TITLE
Enabled immersive nav view to handle RTL

### DIFF
--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -7,6 +7,7 @@ import './d2l-navigation-link-back.js';
 import { navigationSharedStyle } from './d2l-navigation-shared-styles.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 /**
 `d2l-navigation-immersive`
@@ -14,7 +15,7 @@ Polymer-based web component for the immersive navigation component
 
 @demo demo/navigation-immersive.html
 */
-class D2LNavigationImmsersive extends PolymerElement {
+class D2LNavigationImmsersive extends mixinBehaviors([D2L.PolymerBehaviors.FocusableBehavior], PolymerElement) {
 
 	static get properties() {
 		return {
@@ -116,6 +117,11 @@ class D2LNavigationImmsersive extends PolymerElement {
 
 			.d2l-navigation-immersive-middle.d2l-navigation-immersive-middle-no-right-border {
 				border-right: none;
+			}
+
+			:host(:dir(rtl)) .d2l-navigation-immersive-middle.d2l-navigation-immersive-middle-no-right-border {
+				border-left: none;
+				border-right: 1px solid var(--d2l-color-gypsum);
 			}
 
 			div.d2l-navigation-immersive-middle-observer,

--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -7,7 +7,7 @@ import './d2l-navigation-link-back.js';
 import { navigationSharedStyle } from './d2l-navigation-shared-styles.js';
 import { dom } from '@polymer/polymer/lib/legacy/polymer.dom.js';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { DirMixin } from '@polymer/polymer/lib/mixins/dir-mixin.js';
 
 /**
 `d2l-navigation-immersive`
@@ -15,7 +15,7 @@ Polymer-based web component for the immersive navigation component
 
 @demo demo/navigation-immersive.html
 */
-class D2LNavigationImmsersive extends mixinBehaviors([D2L.PolymerBehaviors.FocusableBehavior], PolymerElement) {
+class D2LNavigationImmsersive extends DirMixin(PolymerElement) {
 
 	static get properties() {
 		return {


### PR DESCRIPTION
### Motivation/Context
During FACE development, when trying to add a title to the immersive navigation bar, we noticed that the immersive navigation bar doesn't take into account RTL as the divider between the "Back to {Activity}" button and "Title" renders properly in LTR but disappears in RTL languages. The reason is because we're setting `border-right: none` on `.d2l-navigation-immersive-middle` regardless of language.

#### Current Behaviour
_Notice the divider is rendered on the left_

![image](https://user-images.githubusercontent.com/10677430/103577206-37e25d00-4e89-11eb-9958-4fe4ce9db76d.png)

#### Expected Behaviour
![image](https://user-images.githubusercontent.com/10677430/103577339-71b36380-4e89-11eb-93d4-bd223a62c57d.png)

### Summary of Changes
* Added mixin behaviour to `d2l-navigation-immersive` so that it inherits the `dir` attribute with value equal to either `ltr` or `rtl`
* Added CSS selector to apply the right styling to the host when the locale is a `rtl` language

### Rally Story
https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Fuserstory%2F461506956220&fdp=true?fdp=true

### Related PR
https://github.com/Brightspace/lms/pull/5084