### PR TITLE
Create new stacking context

### DIFF
--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -41,6 +41,7 @@ class D2LNavigationImmsersive extends DirMixin(PolymerElement) {
 			:host {
 				--d2l-navigation-immersive-height-main: 3.1rem;
 				--d2l-navigation-immersive-height-responsive: 2.8rem;
+				z-index: 0;
 			}
 			.d2l-navigiation-immersive-fixed {
 				background-color: white;


### PR DESCRIPTION
## Overview

 Before | After 
------- | ------
 ![image](https://user-images.githubusercontent.com/34746763/123644820-bd6d1700-d7f3-11eb-9052-bc728e52880a.png) | ![image](https://user-images.githubusercontent.com/34746763/123644939-dd9cd600-d7f3-11eb-802a-c11be09c01bb.png) 

Resolves a stacking conflict where clicks would activate the item below.

### Reason for change

See ticket: [DE43686](https://rally1.rallydev.com/#/357251704080ud/workviews?detail=%2Fdefect%2F605803449744&view=aea56dea-ee73-4c07-9842-cc15d4efc0ea&fdp=true?fdp=true): 2. WTD Full view Back to Home link disabled if another link under it

### Changes summarized

- Add `z-index: 0` to create new stacking context.

### Suggested future tasks

* Similar changes could be made to the `list-item` component in core at [this line](https://github.com/BrightspaceUI/core/blob/c7e62af961025cbfd52134e3e154e3cd41a36708/components/list/list-item-generic-layout.js#L60), as suggested [in this slack message](https://d2l.slack.com/archives/C0PHG3QB0/p1624660751355900?thread_ts=1624652794.354900&cid=C0PHG3QB0).

## Checklist

- [x] No new warnings are introduced
- [x] Comments and documentation are up to date
- [x] TODOs resolved or added to issue tracker
- [x] No commented-out code
- [x] This isn't a 'quick-and-dirty' job