### PR TITLE
increase z-index for the immersive navigation

### DIFF
--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -48,7 +48,7 @@ class D2LNavigationImmsersive extends DirMixin(PolymerElement) {
 				position: fixed;
 				right: 0;
 				top: 0;
-				z-index: 2; /* higher than skeletons which could scroll behind immersive nav */
+				z-index: 1002; /* higher than skeletons which could scroll behind immersive nav */
 			}
 			d2l-navigation {
 				border-bottom: 1px solid var(--d2l-color-mica);


### PR DESCRIPTION
This PR is to solve a visual problem [TA159188](https://rally1.rallydev.com/#/?detail=/task/614091004409&fdp=true): minor: Quiz items: settings page causes data reload

the current tooltip has a `z-index` of 1001 which means it is going to be on top of the immersive nav component, increasing the immersive nav `z-index` slightly could fix this visual problem. 
 