### PR TITLE
feat: upgrading visual-diff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Unit Tests (Headless)
         run: npm run test:polymer:local
       - name: Semantic Release
-        uses: BrightspaceUI/actions/semantic-release@master
+        uses: BrightspaceUI/actions/semantic-release@main
         with:
-          DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}

--- a/.github/workflows/visual-diff.yml
+++ b/.github/workflows/visual-diff.yml
@@ -13,9 +13,10 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Visual Diff Tests
-        uses: BrightspaceUI/actions/visual-diff@master
+        uses: BrightspaceUI/actions/visual-diff@main
         with:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TEST_PATH: "./{,!(node_modules)/**}/*.visual-diff.mjs"

--- a/README.md
+++ b/README.md
@@ -216,30 +216,32 @@ npm test
 
 This repo uses the [@brightspace-ui/visual-diff utility](https://github.com/BrightspaceUI/visual-diff/) to compare current snapshots against a set of golden snapshots stored in source control.
 
-The golden snapshots in source control must be updated by Github Actions.  If your PR's code changes result in visual differences, a PR with the new goldens will be automatically opened for you against your branch.
+The golden snapshots in source control must be updated by the [visual-diff GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/visual-diff).  If a pull request results in visual differences, a draft pull request with the new goldens will automatically be opened against its branch.
 
-If you'd like to run the tests locally to help troubleshoot or develop new tests, you can use these commands:
+To run the tests locally to help troubleshoot or develop new tests, first install these dependencies:
 
 ```shell
-# Install dependencies locally
-npm i mocha -g
-npm i @brightspace-ui/visual-diff puppeteer --no-save
+npm install @brightspace-ui/visual-diff@X mocha@Y puppeteer@Z  --no-save
+```
 
+Replace `X`, `Y` and `Z` with [the current versions](https://github.com/BrightspaceUI/actions/tree/main/visual-diff#current-dependency-versions) the action is using.
+
+Then run the tests:
+
+```shell
 # run visual-diff tests
-mocha './test/**/*.visual-diff.js' -t 10000
-
+npx mocha './test/**/*.visual-diff.js' -t 10000
 # subset of visual-diff tests:
-mocha './test/**/*.visual-diff.js' -t 10000 -g some-pattern
-
+npx mocha './test/**/*.visual-diff.js' -t 10000 -g some-pattern
 # update visual-diff goldens
-mocha './test/**/*.visual-diff.js' -t 10000 --golden
+npx mocha './test/**/*.visual-diff.js' -t 10000 --golden
 ```
 
 ## Versioning & Releasing
 
 > TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `main`. Read on for more details...
 
-The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
+The [semantic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/main/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
 
 ### Version Changes
 

--- a/demo/d2l-navigation-button.html
+++ b/demo/d2l-navigation-button.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-band demo</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>

--- a/demo/d2l-navigation-iterator.html
+++ b/demo/d2l-navigation-iterator.html
@@ -5,12 +5,6 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
 		<title>d2l-navigation-iterator demo</title>
-		<script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../node_modules/lie/dist/lie.polyfill.min.js"></script>
-		<script type="module" src="../node_modules/whatwg-fetch/fetch.js"></script>
-		<script type="module" src="../node_modules/url-polyfill/url-polyfill.js"></script>
 
 		<script type="module">
 			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';

--- a/demo/d2l-navigation-link-iterator.html
+++ b/demo/d2l-navigation-link-iterator.html
@@ -5,12 +5,6 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 
 		<title>d2l-navigation-link-iterator demo</title>
-		<script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../node_modules/lie/dist/lie.polyfill.min.js"></script>
-		<script type="module" src="../node_modules/whatwg-fetch/fetch.js"></script>
-		<script type="module" src="../node_modules/url-polyfill/url-polyfill.js"></script>
 
 		<script type="module">
 			import '@polymer/iron-demo-helpers/demo-pages-shared-styles';

--- a/demo/navigation-band.html
+++ b/demo/navigation-band.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-band demo</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots-width-type-normal.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots-width-type-normal.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-immersive demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-immersive-demos/navigation-immersive-all-slots.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-all-slots.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-immersive demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-immersive-demos/navigation-immersive-no-middle-slot.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-no-middle-slot.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-immersive demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-immersive-demos/navigation-immersive-no-right-slot.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-no-right-slot.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-immersive demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-immersive-demos/navigation-immersive-no-slots.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-no-slots.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-immersive demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-immersive-demos/navigation-immersive-responsive-slot-hiding.html
+++ b/demo/navigation-immersive-demos/navigation-immersive-responsive-slot-hiding.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-immersive demo</title>
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-immersive.html
+++ b/demo/navigation-immersive.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-immersive demo</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-main-footer.html
+++ b/demo/navigation-main-footer.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-main-footer demo</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-main-header.html
+++ b/demo/navigation-main-header.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-main-header demo</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation-separator.html
+++ b/demo/navigation-separator.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-separator demo</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>

--- a/demo/navigation.html
+++ b/demo/navigation.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation demo</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "gulp build",
     "lint": "npm run lint:wc && npm run lint:js",
     "lint:js": "eslint . --ext .js,.html test/**/*.js test/**/*.html demo/**/*.js demo/**/*.html",
-    "lint:wc": "polymer lint -i \"./*\" \"test\" \"demo\"",
+    "lint:wc": "polymer lint -i \"./*\" \"test/*.html\" \"demo\"",
     "test:polymer:local": "polymer test --skip-plugin sauce",
     "test:polymer:sauce": "polymer test --skip-plugin local",
     "test": "npm run lint && npm run test:polymer:local"
@@ -20,7 +20,6 @@
     "@polymer/iron-component-page": "^4.0.0",
     "@polymer/iron-demo-helpers": "^3.0.0",
     "@polymer/iron-test-helpers": "^3.0.0",
-    "@webcomponents/webcomponentsjs": "^2.2.7",
     "babel-eslint": "^10.0.1",
     "chromedriver": "^2.40.0",
     "eslint": "^4.19.1",
@@ -31,15 +30,12 @@
     "gulp-cli": "^2.0.1",
     "gulp-ejs": "^3.1.3",
     "gulp-rename": "^1.2.3",
-    "lie": "^3.3.0",
     "merge-stream": "^1.0.1",
     "polymer-cli": "^1.9.6",
     "require-dir": "^1.2.0",
     "sauce-connect-launcher": "^1.2.4",
     "sinon": "^7.3.2",
-    "url-polyfill": "^1.1.3",
-    "wct-browser-legacy": "^1.0.1",
-    "whatwg-fetch": "^3.0.0"
+    "wct-browser-legacy": "^1.0.1"
   },
   "version": "4.5.2",
   "main": "index.js",

--- a/test/d2l-navigation-button.html
+++ b/test/d2l-navigation-button.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-button test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../d2l-navigation-button.js"></script>
 		<script type="module" src="../d2l-navigation-button-notification-icon.js"></script>

--- a/test/d2l-navigation-iterator-item.html
+++ b/test/d2l-navigation-iterator-item.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-iterator-item test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../components/d2l-navigation-iterator/d2l-navigation-iterator-item.js"></script>
 	</head>

--- a/test/d2l-navigation-iterator.html
+++ b/test/d2l-navigation-iterator.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-iterator test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../components/d2l-navigation-iterator/d2l-navigation-iterator.js"></script>
 	</head>

--- a/test/d2l-navigation-link-iterator.html
+++ b/test/d2l-navigation-link-iterator.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-link-iterator test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script src="../node_modules/sinon/pkg/sinon.js"></script>
 		<script type="module" src="../components/d2l-navigation-iterator/d2l-navigation-link-iterator.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 		<title>d2l-navigation tests</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 	</head>
 	<body>

--- a/test/navigation-band.html
+++ b/test/navigation-band.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-band test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../d2l-navigation-band.js"></script>
 	</head>

--- a/test/navigation-immersive.html
+++ b/test/navigation-immersive.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-immersive test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../d2l-navigation-immersive.js"></script>
 	</head>

--- a/test/navigation-main-footer.html
+++ b/test/navigation-main-footer.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-main-footer test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../d2l-navigation-main-footer.js"></script>
 	</head>

--- a/test/navigation-main-header.html
+++ b/test/navigation-main-header.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-main-header test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../d2l-navigation-main-header.js"></script>
 	</head>

--- a/test/navigation-separator.html
+++ b/test/navigation-separator.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation-separator test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../d2l-navigation-separator.js"></script>
 	</head>

--- a/test/navigation.html
+++ b/test/navigation.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
 		<title>d2l-navigation test</title>
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../wct-browser-legacy/browser.js"></script>
 		<script type="module" src="../d2l-navigation.js"></script>
 	</head>

--- a/test/visual-diff/d2l-navigation-band.visual-diff.mjs
+++ b/test/visual-diff/d2l-navigation-band.visual-diff.mjs
@@ -1,12 +1,11 @@
 /* eslint-disable no-invalid-this */
-/* eslint-env node, es6 */
 'use strict';
 
-const puppeteer = require('puppeteer');
-const VisualDiff = require('@brightspace-ui/visual-diff');
+import puppeteer from 'puppeteer';
+import { VisualDiff } from '@brightspace-ui/visual-diff';
 
 describe('d2l-navigation-band', function() {
-	const visualDiff = new VisualDiff('d2l-navigation-band', __dirname);
+	const visualDiff = new VisualDiff('d2l-navigation-band', import.meta.url);
 
 	let browser, page;
 


### PR DESCRIPTION
By switching to the new `main` branch of the actions repo, you pick up the latest visual-diff, mocha@9 and puppeteer@12 -- this will likely case minor visual differences.

If you've seen me make this change in other repos, this PR is different. I didn't switch the whole thing to ESM because `polymer-cli` doesn't like it, and it would require dealing with Gulp and some other things. We can make that switch when this project is converted to Lit. This did mean the visual-diff files need the `.mjs` extension.