### PR TITLE
feat: switch to use `core` for several components

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.png binary

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jeroach @svanherk @CarolBusman

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jeroach @svanherk @CarolBusman
+* @BrightspaceUI/gaudi-dev

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+.github/
+demo/
+screenshots/
+templates/
+test/
+.editorconfig
+.eslintignore
+.eslintrc.json
+.gitattributes
+gulpfile.js
+polymer.json
+wct.conf.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*		@jeroach @svanherk @CarolBusman

--- a/components/d2l-navigation-iterator/d2l-navigation-iterator-item.js
+++ b/components/d2l-navigation-iterator/d2l-navigation-iterator-item.js
@@ -1,8 +1,8 @@
+import '@brightspace-ui/core/components/colors/colors.js';
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 import {NavigationLocalize} from '../NavigationLocalize.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier3-icons.js';
-import 'd2l-tooltip/d2l-tooltip.js';
+import '@brightspace-ui/core/components/icons/icon.js';
+import '@brightspace-ui/core/components/tooltip/tooltip.js';
 import '../../d2l-navigation-button.js';
 
 /**
@@ -124,7 +124,7 @@ class D2LNavigationIteratorItem extends NavigationLocalize(PolymerElement) {
 	}
 
 	_computeIcon(type) {
-		return (type === 'previous') ? 'd2l-tier3:chevron-left-circle' : 'd2l-tier3:chevron-right-circle';
+		return (type === 'previous') ? 'tier3:chevron-left-circle' : 'tier3:chevron-right-circle';
 	}
 }
 

--- a/d2l-navigation-band.js
+++ b/d2l-navigation-band.js
@@ -1,4 +1,4 @@
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import './d2l-navigation-shared-styles';
 
 import {PolymerElement, html} from '@polymer/polymer/polymer-element.js';

--- a/d2l-navigation-button-close.js
+++ b/d2l-navigation-button-close.js
@@ -1,7 +1,5 @@
 
 import './d2l-navigation-button-notification-icon.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
 import 'd2l-button/d2l-button-behavior.js';
 import 'd2l-polymer-behaviors/d2l-focusable-behavior.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
@@ -66,7 +64,7 @@ class D2LNavigationButtonClose extends mixinBehaviors([D2L.PolymerBehaviors.Butt
 				height: 100%;
 			}
 		</style>
-		<d2l-navigation-button-notification-icon class="d2l-focusable" text="[[localize('close')]]" disabled$="[[disabled]]" icon="d2l-tier1:close-large-thick">
+		<d2l-navigation-button-notification-icon class="d2l-focusable" text="[[localize('close')]]" disabled$="[[disabled]]" icon="tier1:close-large-thick">
 
 	</d2l-navigation-button-notification-icon>`;
 		template.setAttribute('strip-whitespace', '');

--- a/d2l-navigation-button-notification-icon.js
+++ b/d2l-navigation-button-notification-icon.js
@@ -1,7 +1,6 @@
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import './d2l-navigation-button.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier2-icons.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import 'd2l-button/d2l-button-behavior.js';
 import 'd2l-polymer-behaviors/d2l-focusable-behavior.js';
 import './d2l-navigation-notification-icon.js';

--- a/d2l-navigation-highlight-styles.js
+++ b/d2l-navigation-highlight-styles.js
@@ -1,4 +1,4 @@
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import { html } from '@polymer/polymer/polymer-element.js';
 export const highlightStyles = html`
 				<style>

--- a/d2l-navigation-immersive.js
+++ b/d2l-navigation-immersive.js
@@ -1,4 +1,4 @@
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import 'fastdom/fastdom.js';
 import ResizeObserver from 'resize-observer-polyfill/dist/ResizeObserver.es.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';

--- a/d2l-navigation-link-back.js
+++ b/d2l-navigation-link-back.js
@@ -1,7 +1,5 @@
-import 'd2l-colors/d2l-colors.js';
 import './d2l-navigation-link.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier1-icons.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import 'd2l-polymer-behaviors/d2l-focusable-behavior.js';
 import 'd2l-localize-behavior/d2l-localize-behavior.js';
 
@@ -71,7 +69,7 @@ class D2LNavigationLinkBack extends mixinBehaviors([D2L.PolymerBehaviors.Link.Be
 			}
 		</style>
 		<d2l-navigation-link href="[[href]]" class="d2l-focusable" text="[[_getDisplayText(text, localize)]]">
-			<d2l-icon icon="d2l-tier1:chevron-left"></d2l-icon>
+			<d2l-icon icon="tier1:chevron-left"></d2l-icon>
 			<span class="d2l-navigation-link-back-text">[[_getDisplayText(text, localize)]]</span>
 		</d2l-navigation-link>
 		`;

--- a/d2l-navigation-main-footer.js
+++ b/d2l-navigation-main-footer.js
@@ -1,4 +1,3 @@
-import 'd2l-colors/d2l-colors.js';
 import { navigationSharedStyle } from './d2l-navigation-shared-styles.js';
 
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';

--- a/d2l-navigation-notification-icon.js
+++ b/d2l-navigation-notification-icon.js
@@ -1,4 +1,4 @@
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 /**

--- a/d2l-navigation-separator.js
+++ b/d2l-navigation-separator.js
@@ -1,6 +1,5 @@
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier2-icons.js';
-
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 /**
 `d2l-navigation-separator`
@@ -21,7 +20,7 @@ class D2LNavigationSeparator extends PolymerElement {
 				color: var(--d2l-color-mica);
 			}
 		</style>
-		<d2l-icon icon="d2l-tier2:divider-big"></d2l-icon>
+		<d2l-icon icon="tier2:divider-big"></d2l-icon>
 		`;
 		template.setAttribute('strip-whitespace', '');
 		return template;

--- a/demo/d2l-navigation-button.html
+++ b/demo/d2l-navigation-button.html
@@ -7,8 +7,7 @@
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>
-		<script type="module" src="../../d2l-icons/d2l-icon.js"></script>
-		<script type="module" src="../../d2l-icons/tier3-icons.js"></script>
+		<script type="module" src="/node_modules/@brightspace-ui/core/components/icons/icon.js"></script>
 		<script type="module" src="../d2l-navigation-button-notification-icon.js"></script>
 		<script type="module" src="../d2l-navigation-button-close.js"></script>
 		<script type="module" src="../d2l-navigation-link-back.js"></script>
@@ -78,11 +77,11 @@ $_documentContainer.innerHTML = `<div class="vertical-section-container centered
 					</style>
 					<d2l-navigation-band></d2l-navigation-band>
 					<div class="button-holder">
-						<d2l-navigation-button><span><d2l-icon icon="d2l-tier3:classes"></d2l-icon><span>TEST</span></span></d2l-navigation-button>
-						<d2l-navigation-button-notification-icon icon="d2l-tier3:classes" text="Notification off" notification-text="This text will not be added"></d2l-navigation-button-notification-icon>
-						<d2l-navigation-button-notification-icon notification="" icon="d2l-tier3:notification-bell" text="Notification on" id="notified" notification-text="You have new notifications"></d2l-navigation-button-notification-icon>
+						<d2l-navigation-button><span><d2l-icon icon="tier3:classes"></d2l-icon><span>TEST</span></span></d2l-navigation-button>
+						<d2l-navigation-button-notification-icon icon="tier3:classes" text="Notification off" notification-text="This text will not be added"></d2l-navigation-button-notification-icon>
+						<d2l-navigation-button-notification-icon notification="" icon="tier3:notification-bell" text="Notification on" id="notified" notification-text="You have new notifications"></d2l-navigation-button-notification-icon>
 						<d2l-navigation-button-close></d2l-navigation-button-close>
-						<d2l-navigation-button-notification-icon icon="d2l-tier3:classes" text="text" disabled=""></d2l-navigation-button-notification-icon>
+						<d2l-navigation-button-notification-icon icon="tier3:classes" text="text" disabled=""></d2l-navigation-button-notification-icon>
 						<d2l-navigation-button-close disabled=""></d2l-navigation-button-close>
 					</div>
 					<br>
@@ -125,8 +124,7 @@ document.body.appendChild($_documentContainer.content);
 import '@polymer/iron-demo-helpers/demo-pages-shared-styles.js';
 import '@polymer/iron-demo-helpers/demo-snippet.js';
 import 'd2l-typography/d2l-typography.js';
-import 'd2l-icons/d2l-icon.js';
-import 'd2l-icons/tier3-icons.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import '../d2l-navigation-button-notification-icon.js';
 import '../d2l-navigation-button-close.js';
 import '../d2l-navigation-link-back.js';

--- a/package.json
+++ b/package.json
@@ -40,17 +40,15 @@
   "version": "4.6.0",
   "main": "index.js",
   "dependencies": {
-    "@polymer/polymer": "^3.0.0",
+    "@brightspace-ui/core": "^1",
+    "@polymer/polymer": "^3",
     "d2l-button": "BrightspaceUI/button#semver:^5",
-    "d2l-colors": "BrightspaceUI/colors#semver:^4",
-    "d2l-icons": "BrightspaceUI/icons#semver:^6",
     "d2l-link": "BrightspaceUI/link#semver:^5",
     "d2l-localize-behavior": "BrightspaceUI/localize-behavior#semver:^2",
     "d2l-offscreen": "BrightspaceUI/offscreen#semver:^4",
     "d2l-polymer-behaviors": "Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "d2l-tooltip": "BrightspaceUI/tooltip#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
-    "fastdom": "^1.0.8",
-    "resize-observer-polyfill": "^1.5.0"
+    "fastdom": "^1",
+    "resize-observer-polyfill": "^1"
   }
 }

--- a/test/d2l-navigation-iterator-item.html
+++ b/test/d2l-navigation-iterator-item.html
@@ -56,9 +56,9 @@ suite('d2l-navigation-iterator-item', function() {
 		assert.equal(span.hidden, true);
 	});
 	test('_computeIcon returns the correct icon based on type', function() {
-		assert.equal(button._icon, 'd2l-tier3:chevron-left-circle');
+		assert.equal(button._icon, 'tier3:chevron-left-circle');
 		button.type = 'next';
-		assert.equal(button._icon, 'd2l-tier3:chevron-right-circle');
+		assert.equal(button._icon, 'tier3:chevron-right-circle');
 	});
 });
 suite('d2l-navigation-iterator-item with next type', function() {


### PR DESCRIPTION
The ones removed were all drop in replacements. The ones not removed used various style shims or polymer behaviours that can't be removed at the moment. Doing this as part of an effort to minimize github/git style dependency refs in package.json files. NPM 8 has issues with them and can greatly increase install time (`d2l-rubric` takes 2 min to install with NPM 6 and without any changes takes 30 min with NPM 8).