### PR TITLE
BREAKING CHANGE: Lit 2 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@brightspace-ui/stylelint-config": "^0.3",
-    "@open-wc/testing": "^2",
+    "@open-wc/testing": "^3",
     "@web/dev-server": "^0.1",
     "@web/test-runner": "^0.13",
     "babel-eslint": "^10.0.1",
@@ -56,15 +56,15 @@
     "stylelint": "^14"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^1",
+    "@brightspace-ui/core": "^2",
     "@polymer/polymer": "^3",
-    "d2l-button": "github:BrightspaceUI/button#semver:^5",
-    "d2l-link": "github:BrightspaceUI/link#semver:^5",
+    "d2l-button": "github:BrightspaceUI/button#semver:^6",
+    "d2l-link": "github:BrightspaceUI/link#semver:^6",
     "d2l-localize-behavior": "github:BrightspaceUI/localize-behavior#semver:^2",
-    "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^2",
-    "d2l-typography": "github:BrightspaceUI/typography#semver:^7",
+    "d2l-polymer-behaviors": "github:Brightspace/d2l-polymer-behaviors-ui#semver:^3",
+    "d2l-typography": "github:BrightspaceUI/typography#semver:^8",
     "fastdom": "^1",
-    "lit-element": "^2",
+    "lit-element": "^3",
     "resize-observer-polyfill": "^1"
   }
 }


### PR DESCRIPTION
This PR makes the breaking changes required to update to Lit 2 (`lit-html` 2 and `lit-element` 3). The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.

Breaking change checklist: 
- [x] Update `lit-html` -> `^2`, `lit-element` -> `^3`, `open-wc/testing` -> `^3` (if used)
- [x] `createRenderRoot` usages -> move from LitElement to ReactiveElement 
- [x] Remove Dependabot Lit rules
- [x] Bump any dependencies to their Lit 2 versions
- [x] Remove any manual lifecycle calls to Lit 1 reactive controllers
- [x] Backwards-compatible changes merged: N/A

Renamed API's:
- [x] `UpdatingElement` -> `ReactiveElement`
- [x] `@internalProperty` -> `@state` (we don't use TypeScript decorators)
- [x] `static getStyles()` -> `static finalizeStyles(styles)`
- [x] `_getUpdateComplete()` -> `getUpdateComplete()`
- [x] `NodePart` -> `ChildPart`

Testing checklist: 
- [x] CI/ unit tests pass
- [x] Local testing on demo pages
- [ ] Testing component in the LMS

For more information on the Lit 2 upgrade, visit https://lit.dev/docs/releases/upgrade/ or contact team Gaudi.